### PR TITLE
Fix UI issue on /puzzles/new page

### DIFF
--- a/routes/puzzles/new.tsx
+++ b/routes/puzzles/new.tsx
@@ -6,6 +6,7 @@ import Board from "#/islands/board.tsx";
 import { EditorPanel } from "#/islands/editor-panel.tsx";
 import { define } from "#/routes/core.ts";
 import { Puzzle } from "#/util/types.ts";
+import { Main } from "../../components/main.tsx";
 
 export const handler = define.handlers<Puzzle>({
   GET() {
@@ -35,7 +36,7 @@ export default define.page(function EditorPage(props: PageProps<Puzzle>) {
 
   return (
     <>
-      <div class="flex flex-col col-[2/3] w-full gap-fl-2 pt-fl-2">
+      <Main>
         <Header items={navItems} />
 
         <h1 className="text-5 text-brand">New puzzle</h1>
@@ -45,7 +46,7 @@ export default define.page(function EditorPage(props: PageProps<Puzzle>) {
           href={href}
           mode={mode}
         />
-      </div>
+      </Main>
 
       <EditorPanel puzzle={puzzle} href={href} />
     </>


### PR DESCRIPTION
Fixed a relatively simple layout issue, where the /puzzles/new page was not using the `Main` component yet.

**Before:**

<img width="1512" height="899" alt="Screenshot 2026-02-04 at 08 57 34" src="https://github.com/user-attachments/assets/0eb999fd-d8cd-46ee-9e9d-e56e500edf8d" />

**After:**

<img width="1512" height="942" alt="Screenshot 2026-02-04 at 08 57 21" src="https://github.com/user-attachments/assets/c876a3f9-aa8a-44da-8505-435b0c2a24e3" />
