### PR TITLE
Refactor all single character query params to full names

### DIFF
--- a/components/pagination.tsx
+++ b/components/pagination.tsx
@@ -13,9 +13,9 @@ export function Pagination({ page, totalPages, baseUrl }: Props) {
   const getPageUrl = (page: number) => {
     const url = new URL(baseUrl);
     if (page === 1) {
-      url.searchParams.delete("p");
+      url.searchParams.delete("page");
     } else {
-      url.searchParams.set("p", page.toString());
+      url.searchParams.set("page", page.toString());
     }
     return url.pathname + url.search;
   };

--- a/islands/board.tsx
+++ b/islands/board.tsx
@@ -98,7 +98,7 @@ export default function Board(
   const replaySpeed = useMemo(() => {
     const url = new URL(href.value);
 
-    const name = url.searchParams.get("r");
+    const name = url.searchParams.get("replay_speed");
     const value = getReplaySpeed(name);
 
     return isNaN(value) ? 1 : value;

--- a/islands/tutorial-dialog.tsx
+++ b/islands/tutorial-dialog.tsx
@@ -16,7 +16,7 @@ export const TutorialDialog = function ({ open, href, mode, solution }: Props) {
 
   const step = useMemo(() => {
     const url = new URL(href.value);
-    const rawValue = url.searchParams.get("s");
+    const rawValue = url.searchParams.get("step");
     const value = rawValue && parseInt(rawValue, 10);
 
     return !value || isNaN(value) ? 0 : value;
@@ -25,7 +25,7 @@ export const TutorialDialog = function ({ open, href, mode, solution }: Props) {
   const replaySpeed = useMemo(() => {
     const url = new URL(href.value);
 
-    const name = url.searchParams.get("r");
+    const name = url.searchParams.get("replay_speed");
     const value = name === "slow" ? 1.5 : 1;
 
     return isNaN(value) ? 1 : value;
@@ -227,9 +227,9 @@ function getStepLink(
   { replay }: GetStepLinkOptions = {},
 ) {
   const url = new URL(href);
-  url.searchParams.set("s", step.toString());
+  url.searchParams.set("step", step.toString());
 
-  if (replay) url.searchParams.set("r", replay);
+  if (replay) url.searchParams.set("replay_speed", replay);
 
   return url.href;
 }

--- a/routes/puzzles/[slug]/solutions/[[solutionId]].tsx
+++ b/routes/puzzles/[slug]/solutions/[[solutionId]].tsx
@@ -42,7 +42,7 @@ export const handler = define.handlers<Data>({
     }
 
     const url = new URL(req.url);
-    if (!url.searchParams.has("m") && solution) {
+    if (!url.searchParams.has("moves") && solution) {
       url.search = encodeState(solution);
 
       return Response.redirect(url);

--- a/routes/puzzles/tutorial.tsx
+++ b/routes/puzzles/tutorial.tsx
@@ -24,12 +24,12 @@ export const handler = define.handlers<Data>({
     if (!solutionRaw) throw new Error("Tutorial puzzle solution not found");
 
     const redirectUrl = new URL(ctx.url);
-    redirectUrl.searchParams.set("m", solutionRaw);
+    redirectUrl.searchParams.set("moves", solutionRaw);
 
     const puzzle = await getPuzzle(ctx.url.origin, "tutorial");
     if (!puzzle) throw new Error("Tutorial puzzle not found");
 
-    if (!ctx.url.searchParams.has("m")) {
+    if (!ctx.url.searchParams.has("moves")) {
       return Response.redirect(redirectUrl);
     }
 
@@ -63,7 +63,7 @@ export default define.page(function PuzzleTutorial(props: PageProps<Data>) {
   const href = useSignal(props.url.href);
   const puzzle = useSignal(props.data.puzzle);
   const mode = useSignal<"readonly" | "replay">(
-    props.url.searchParams.has("r") ? "replay" : "readonly",
+    props.url.searchParams.has("replay_speed") ? "replay" : "readonly",
   );
 
   const navItems = [

--- a/util/url.ts
+++ b/util/url.ts
@@ -28,15 +28,15 @@ export function encodeState({ moves, active, cursor }: GameState) {
   const params = new URLSearchParams();
 
   if (moves.length) {
-    params.set("m", encodeMoves(moves));
+    params.set("moves", encodeMoves(moves));
   }
 
   if (active != null) {
-    params.set("a", encodePosition(active));
+    params.set("active", encodePosition(active));
   }
 
   if (cursor != null) {
-    params.set("c", cursor.toString());
+    params.set("cursor", cursor.toString());
   }
 
   return params.toString();
@@ -52,13 +52,13 @@ export function decodeState(urlOrHref: URL | string): GameState {
   const url = new URL(urlOrHref);
   const params = url.searchParams;
 
-  const moveParam = params.get("m");
+  const moveParam = params.get("moves");
   const moves = moveParam ? decodeMoves(moveParam) : [];
 
-  const activeParam = params.get("a");
+  const activeParam = params.get("active");
   const active = activeParam ? decodePosition(activeParam) : undefined;
 
-  const cursorParam = params.get("c");
+  const cursorParam = params.get("cursor");
   const cursor = cursorParam ? parseInt(cursorParam) : undefined;
 
   return {
@@ -146,9 +146,9 @@ export function getRedoHref(
 export function getResetHref(href: string) {
   const url = new URL(href);
 
-  url.searchParams.delete("a");
-  url.searchParams.delete("c");
-  url.searchParams.delete("m");
+  url.searchParams.delete("active");
+  url.searchParams.delete("cursor");
+  url.searchParams.delete("moves");
 
   return url.href;
 }
@@ -156,7 +156,7 @@ export function getResetHref(href: string) {
 export function getPage(
   url: URL,
 ) {
-  const pageParam = url.searchParams.get("p");
+  const pageParam = url.searchParams.get("page");
 
   if (!pageParam) return 1;
 

--- a/util/url_test.ts
+++ b/util/url_test.ts
@@ -17,12 +17,12 @@ Deno.test("encodeState() should add all params", () => {
     cursor: 3,
   });
 
-  assertEquals(result, "m=A1A6&a=F1&c=3");
+  assertEquals(result, "moves=A1A6&active=F1&cursor=3");
 });
 
 Deno.test("decodeState() should extract all params", () => {
   const url = new URL("http://example.com");
-  url.search = "?m=F6F3&a=H8&c=0";
+  url.search = "?moves=F6F3&active=H8&cursor=0";
   const result = decodeState(url);
 
   assertEquals(result, {
@@ -44,7 +44,7 @@ Deno.test("getMoveHref() should append move and update cursor", () => {
     },
   );
 
-  assertEquals(result, "http://example.com/?m=A1A6&a=A6&c=1");
+  assertEquals(result, "http://example.com/?moves=A1A6&active=A6&cursor=1");
 });
 
 Deno.test("getMoveHref() should truncate moves at cursor position", () => {
@@ -60,7 +60,10 @@ Deno.test("getMoveHref() should truncate moves at cursor position", () => {
     },
   );
 
-  assertEquals(result, "http://example.com/?m=A1A6-C3C8&a=C8&c=2");
+  assertEquals(
+    result,
+    "http://example.com/?moves=A1A6-C3C8&active=C8&cursor=2",
+  );
 });
 
 Deno.test("getActiveHref() should set active position", () => {
@@ -73,7 +76,7 @@ Deno.test("getActiveHref() should set active position", () => {
     },
   );
 
-  assertEquals(result, "http://example.com/?m=A1A6&a=D5&c=1");
+  assertEquals(result, "http://example.com/?moves=A1A6&active=D5&cursor=1");
 });
 
 Deno.test("getUndoHref() should decrement cursor", () => {
@@ -85,7 +88,7 @@ Deno.test("getUndoHref() should decrement cursor", () => {
     cursor: 2,
   });
 
-  assertEquals(result, "http://example.com/?m=A1A6-F6&c=1");
+  assertEquals(result, "http://example.com/?moves=A1A6-F6&cursor=1");
 });
 
 Deno.test("getUndoHref() should not go below zero", () => {
@@ -94,7 +97,7 @@ Deno.test("getUndoHref() should not go below zero", () => {
     cursor: 0,
   });
 
-  assertEquals(result, "http://example.com/?m=A1A6&c=0");
+  assertEquals(result, "http://example.com/?moves=A1A6&cursor=0");
 });
 
 Deno.test("getRedoHref() should increment cursor", () => {
@@ -106,7 +109,7 @@ Deno.test("getRedoHref() should increment cursor", () => {
     cursor: 0,
   });
 
-  assertEquals(result, "http://example.com/?m=A1A6-F6&c=1");
+  assertEquals(result, "http://example.com/?moves=A1A6-F6&cursor=1");
 });
 
 Deno.test("getRedoHref() should not exceed moves length", () => {
@@ -115,11 +118,13 @@ Deno.test("getRedoHref() should not exceed moves length", () => {
     cursor: 1,
   });
 
-  assertEquals(result, "http://example.com/?m=A1A6&c=1");
+  assertEquals(result, "http://example.com/?moves=A1A6&cursor=1");
 });
 
 Deno.test("getResetHref() should remove all game params", () => {
-  const result = getResetHref("http://example.com/?m=A1A6&a=F1&c=1&other=kept");
+  const result = getResetHref(
+    "http://example.com/?moves=A1A6&active=F1&cursor=1&other=kept",
+  );
 
   assertEquals(result, "http://example.com/?other=kept");
 });


### PR DESCRIPTION
Pure refactor, getting rid of the "cute" single character query param keys in favor of readable ones.

**Regression proof:**

https://github.com/user-attachments/assets/e3bdb18e-fcff-4707-b44d-f54bb9685bb6