### PR TITLE
Remove all PageProps usages

### DIFF
--- a/routes/puzzles/[slug]/edit/index.tsx
+++ b/routes/puzzles/[slug]/edit/index.tsx
@@ -1,5 +1,5 @@
 import { useSignal } from "@preact/signals";
-import { HttpError, page, PageProps } from "fresh";
+import { HttpError, page } from "fresh";
 
 import { Header } from "#/components/header.tsx";
 import { Main } from "#/components/main.tsx";
@@ -27,7 +27,7 @@ export const handler = define.handlers<Puzzle>({
 });
 
 // TODO: if on localhost, save directly to disc
-export default define.page(function EditorPage(props: PageProps<Puzzle>) {
+export default define.page<typeof handler>(function EditorPage(props) {
   const slug = props.data.slug;
   const puzzle = useSignal(props.data);
   const href = useSignal(props.url.href);

--- a/routes/puzzles/[slug]/solutions/[[solutionId]].tsx
+++ b/routes/puzzles/[slug]/solutions/[[solutionId]].tsx
@@ -1,5 +1,5 @@
 import { useSignal } from "@preact/signals";
-import { HttpError, page, PageProps } from "fresh";
+import { HttpError, page } from "fresh";
 
 import { Header } from "#/components/header.tsx";
 import { Main } from "#/components/main.tsx";
@@ -59,7 +59,7 @@ export const handler = define.handlers<Data>({
   },
 });
 
-export default define.page(function SolutionPage(props: PageProps<Data>) {
+export default define.page<typeof handler>(function SolutionPage(props) {
   const puzzle = useSignal(props.data.puzzle);
   const href = useSignal(props.url.href);
   const mode = useSignal<"replay">("replay");

--- a/routes/puzzles/new.tsx
+++ b/routes/puzzles/new.tsx
@@ -1,5 +1,5 @@
 import { useSignal } from "@preact/signals";
-import { page, PageProps } from "fresh";
+import { page } from "fresh";
 
 import { Header } from "#/components/header.tsx";
 import { Main } from "#/components/main.tsx";
@@ -26,7 +26,7 @@ export const handler = define.handlers<Puzzle>({
   },
 });
 
-export default define.page(function EditorPage(props: PageProps<Puzzle>) {
+export default define.page<typeof handler>(function EditorPage(props) {
   const puzzle = useSignal(props.data);
   const href = useSignal(props.url.href);
   const mode = useSignal<"editor">("editor");

--- a/routes/puzzles/tutorial.tsx
+++ b/routes/puzzles/tutorial.tsx
@@ -1,5 +1,5 @@
 import { useSignal } from "@preact/signals";
-import { HttpError, page, PageProps } from "fresh";
+import { HttpError, page } from "fresh";
 
 import { Header } from "#/components/header.tsx";
 import { Main } from "#/components/main.tsx";
@@ -61,7 +61,7 @@ export const handler = define.handlers<Data>({
   },
 });
 
-export default define.page(function PuzzleTutorial(props: PageProps<Data>) {
+export default define.page<typeof handler>(function PuzzleTutorial(props) {
   const href = useSignal(props.url.href);
   const puzzle = useSignal(props.data.puzzle);
   const mode = useSignal<"readonly" | "replay">(


### PR DESCRIPTION
turns out `define.page<typeof handler>(` has fantastic support, so PageProps is never needed

**Demo**

NA. just types, if it builds we are good