### PR TITLE
Fix dialog bug for SolutionDialog

### DIFF
--- a/islands/dialog.tsx
+++ b/islands/dialog.tsx
@@ -1,5 +1,5 @@
 import type { DialogHTMLAttributes } from "preact";
-import { useEffect, useRef } from "preact/hooks";
+import { useLayoutEffect, useRef } from "preact/hooks";
 
 import { clsx } from "clsx/lite";
 
@@ -8,7 +8,7 @@ type Props = DialogHTMLAttributes<HTMLDialogElement>;
 export function Dialog({ open, className, children, ...rest }: Props) {
   const ref = useRef<HTMLDialogElement>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     ref.current?.close();
     if (open) ref.current?.showModal();
   }, [open]);

--- a/islands/solution-dialog.tsx
+++ b/islands/solution-dialog.tsx
@@ -32,6 +32,7 @@ export function SolutionDialog({ open, href, puzzle }: Props) {
             name="name"
             autocomplete="username name"
             placeholder="fx. Jungleboi87"
+            required
             className="border border-none p-2 bg-none text-2 rounded-1"
           />
         </label>
@@ -45,6 +46,7 @@ export function SolutionDialog({ open, href, puzzle }: Props) {
         <button
           className="btn place-self-start"
           type="submit"
+          disabled={!open}
         >
           Submit solution
         </button>
@@ -64,6 +66,7 @@ export function SolutionDialog({ open, href, puzzle }: Props) {
             type="submit"
             className="underline text-ui-4 bg-transparent"
             formNoValidate
+            disabled={!open}
           >
             close
           </button>

--- a/islands/tutorial-dialog.tsx
+++ b/islands/tutorial-dialog.tsx
@@ -44,7 +44,7 @@ export const TutorialDialog = function ({ open, href, mode, solution }: Props) {
         animationDelay: `${(1 / replaySpeed) * solution.moves.length}s`,
       }}
     >
-      {step === 0 && <TutorialWelcomeStep href={href.value} />}
+      {step === 0 && <TutorialWelcomeStep href={href.value} open={open} />}
       {step === 1 && <TutorialPiecesStep href={href.value} />}
       {step === 2 && (
         <TutorialSolutionStep href={href.value} solution={solution} />
@@ -55,9 +55,10 @@ export const TutorialDialog = function ({ open, href, mode, solution }: Props) {
 
 type TutorialStepProps = {
   href: string;
+  open?: boolean;
 };
 
-function TutorialWelcomeStep({ href }: TutorialStepProps) {
+function TutorialWelcomeStep({ href, open }: TutorialStepProps) {
   const nextStep = useMemo(() => getStepLink(href, 1), [
     href,
   ]);
@@ -85,7 +86,11 @@ function TutorialWelcomeStep({ href }: TutorialStepProps) {
         method="POST"
         className="flex w-full"
       >
-        <button type="submit" className="btn mr-auto">
+        <button
+          type="submit"
+          className="btn mr-auto"
+          disabled={!open}
+        >
           Dismiss
         </button>
 


### PR DESCRIPTION
There is an issue on SolutionDialog, where the user would submit the form on opening it.
This safeguards it using the following
- required on username
- disabled on form submit buttons when dialog not open
- useLayoutEffect for showing Dialog

**Regression proof:**

https://github.com/user-attachments/assets/b01f0250-8c84-4f02-a182-609298ee478c