### PR TITLE
Add high contrast theme instead of one-dark for vision deficiency

### DIFF
--- a/game/cookies.ts
+++ b/game/cookies.ts
@@ -18,7 +18,7 @@ const TRACKING_DURATION = 1000 * 60 * 60 * 24 * 365;
 
 const THEME_VALUES = [
   "skub",
-  "one-dark",
+  "high-contrast",
   "dracula",
   "acid",
   "github-light",

--- a/islands/theme-picker.tsx
+++ b/islands/theme-picker.tsx
@@ -20,10 +20,10 @@ const THEMES: Theme[] = [
     mode: "dark",
   },
   {
-    key: "one-dark",
-    label: "One Dark",
-    surface: "#21252b",
-    brand: "#98c379",
+    key: "high-contrast",
+    label: "High Contrast",
+    surface: "#000000",
+    brand: "#ffffff",
     mode: "dark",
   },
   {

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -103,7 +103,7 @@ export default define.page<typeof handler>(function Home(ctx) {
       </Main>
 
       <Panel className="max-lg:gap-fl-3">
-        <p className="col-[2/3] text-fl-0 text-text-3 lg:col-auto lg:row-start-1">
+        <p className="col-[2/3] text-fl-0 text-text-2 lg:col-auto lg:row-start-1">
           Inspired by{" "}
           <a href="https://boardgamegeek.com/boardgame/51/ricochet-robots">
             Ricochet Robots
@@ -138,13 +138,13 @@ export default define.page<typeof handler>(function Home(ctx) {
           <div className="flex gap-2 lg:flex-col">
             <a
               href="https://github.com/kasperstorgaard/ricochet"
-              className="text-text-3"
+              className="text-text-2"
             >
               <i className="ph ph-github-logo" /> GitHub
             </a>
             <a
               href="https://www.linkedin.com/in/kasper-storgaard-t-lead"
-              className="text-text-3"
+              className="text-text-2"
             >
               <i className="ph ph-linkedin-logo" /> LinkedIn
             </a>

--- a/styles/themes.css
+++ b/styles/themes.css
@@ -32,24 +32,30 @@
   --color-ui-contrast: var(--pink-7);
 }
 
-/* One Dark Pro */
-:root[data-theme="one-dark"] {
+/* High Contrast / A11y — Wong (2011) / Okabe-Ito colorblind-safe palette.
+   All ui colors pass WCAG AAA (7:1) on pure black.
+   surface-4 = surface-3 (collapsed) to keep text-3 above AA on elevated surfaces. */
+:root[data-theme="high-contrast"] {
   color-scheme: dark;
-  --btn-active-text: #21252b;
-  --color-surface-1: #21252b;
-  --color-surface-2: #282c34;
-  --color-surface-3: #2c313c;
-  --color-surface-4: #3e4451;
-  --color-text-1: #abb2bf;
-  --color-text-2: #828997;
-  --color-text-3: #5c6370;
-  --color-brand: #98c379;
-  --color-link: #61afef;
-  --color-ui-1: #56b6c2;
-  --color-ui-2: #e5c07b;
-  --color-ui-3: #c678dd;
-  --color-ui-4: #d19a66;
-  --color-ui-contrast: #98c379;
+  --btn-active-text: #000000;
+
+  --color-brand: #ffffff;
+  --color-link: var(--blue-3);
+
+  --color-surface-1: #000000;
+  --color-surface-2: #0d0d0d;
+  --color-surface-3: #1a1a1a;
+  --color-surface-4: #1a1a1a;
+
+  --color-text-1: #ffffff;
+  --color-text-2: #cccccc;
+  --color-text-3: #888888;
+
+  --color-ui-1: var(--blue-3); /* destination — sky blue   — 10.7:1 */
+  --color-ui-2: var(--yellow-7); /* puck        — orange     — 9.8:1  */
+  --color-ui-3: var(--pink-5); /* blockers    — warm pink  — 7.0:1  */
+  --color-ui-4: var(--gray-4); /* walls       — cool gray  — 14.0:1 */
+  --color-ui-contrast: #000000;
 }
 
 /* Dracula */


### PR DESCRIPTION
So some of the themes are _questionable_ for a11y / vision deficiencies, so added a high contrast one for people who like that.

Also removed a couple of text-3 usages, because it is very dim. should only be used for very supportive text

**Demo**


https://github.com/user-attachments/assets/a5820ff2-e296-48ee-ad51-4996c4d5676d

