### PR TITLE
Fix middleware issue where cookies would be set on existing request

### DIFF
--- a/middleware/user.ts
+++ b/middleware/user.ts
@@ -42,14 +42,22 @@ export const user = define.middleware(async (ctx) => {
     // One-time migration: read legacy cookies and write to KV
     await migrateLegacyCookies(ctx.req.headers, userId);
 
-    // Set the user_id cookie on the response
-    setCookie(response.headers, {
+    // Response.redirect() and some Fresh responses use immutable headers,
+    // so copy into a new mutable Headers before setting the cookie.
+    const headers = new Headers(response.headers);
+    setCookie(headers, {
       name: USER_ID_KEY,
       value: userId,
       httpOnly: true,
       path: "/",
       secure: !isDev,
       maxAge: USER_ID_DURATION,
+    });
+
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
     });
   }
 


### PR DESCRIPTION
As the title, we should never set cookies on existing requests

## Demo

**Before**

https://github.com/user-attachments/assets/fc4e23a5-aa76-4ea6-81d3-c313be3bdd23

**After**


https://github.com/user-attachments/assets/d4616e24-dce6-4962-9a39-5da90ff8b6b7

