### PR TITLE
Autofocus tutorial next button

### DIFF
--- a/islands/tutorial-dialog.tsx
+++ b/islands/tutorial-dialog.tsx
@@ -97,6 +97,7 @@ function TutorialWelcomeStep({ href, open }: TutorialStepProps) {
           href={nextStep}
           className="btn ml-auto"
           data-router="push"
+          autoFocus
         >
           Next
         </a>


### PR DESCRIPTION
When starting the tutorial, the "Next" button should be autofocused

## Demo

<!-- screenshots / screen recording here -->

https://github.com/user-attachments/assets/091a7601-aef9-4113-bee6-c1b7600d00e2

