### PR TITLE
Use Deno.cwd for puzzles dir

### DIFF
--- a/game/loader.ts
+++ b/game/loader.ts
@@ -9,9 +9,8 @@ import {
 } from "#/game/types.ts";
 import { sortList } from "#/lib/list.ts";
 
-// Resolve path relative to this module file — works across all envs (local, CI, Deno Deploy).
-// See https://docs.deno.com/runtime/tutorials/module_metadata/
-const PUZZLES_DIR = new URL("../static/puzzles", import.meta.url).pathname;
+// Resolve from cwd — always the project root locally and on Deno Deploy.
+const PUZZLES_DIR = `${Deno.cwd()}/static/puzzles`;
 
 // Default items per page
 const ITEMS_PER_PAGE = 6;


### PR DESCRIPTION
So that was a pretty bad bug, so we gotta use Deno.cwd it seems

## Demo

https://github.com/user-attachments/assets/a213f245-b41f-484c-9dc7-e28bd83acbbc