### PR TITLE
Add more otel attributes, wrap kv calls in spans

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -4,6 +4,7 @@ import { State } from "#/core.ts";
 import { auth } from "#/middleware/auth.ts";
 import { onboarding } from "#/middleware/onboarding.ts";
 import { posthogProxy } from "#/middleware/posthog-proxy.ts";
+import { telemetry } from "#/middleware/telemetry.ts";
 import { theme } from "#/middleware/theme.ts";
 import { tracking } from "#/middleware/tracking.ts";
 
@@ -13,6 +14,7 @@ export const app = new App<State>();
 app.use(staticFiles());
 
 // Add middlewares
+app.use(telemetry);
 app.use(posthogProxy);
 app.use(tracking);
 app.use(auth);

--- a/middleware/auth.ts
+++ b/middleware/auth.ts
@@ -13,15 +13,34 @@ export const auth = define.middleware((ctx) =>
   tracer.startActiveSpan("middleware.auth", async (span) => {
     try {
       const sessionId = getAuthSessionId(ctx.req.headers);
-      const session = sessionId ? await getAuthSession(sessionId) : null;
+      const session = sessionId
+        ? await tracer.startActiveSpan("kv.getAuthSession", async (s) => {
+          try {
+            return await getAuthSession(sessionId);
+          } finally {
+            s.end();
+          }
+        })
+        : null;
 
       let userId = session?.userId ?? getUserIdCookie(ctx.req.headers);
       const isNew = !userId;
       if (!userId) userId = crypto.randomUUID();
 
       ctx.state.userId = userId;
+      span.setAttribute("user.id", userId);
+
       if (session) {
-        ctx.state.email = (await getUserEmail(userId)) ?? undefined;
+        ctx.state.email = await tracer.startActiveSpan(
+          "kv.getUserEmail",
+          async (span) => {
+            try {
+              return (await getUserEmail(userId)) ?? undefined;
+            } finally {
+              span.end();
+            }
+          },
+        );
       }
 
       const response = await ctx.next();

--- a/middleware/onboarding.ts
+++ b/middleware/onboarding.ts
@@ -9,7 +9,17 @@ import { tracer } from "#/lib/telemetry.ts";
 export const onboarding = define.middleware((ctx) =>
   tracer.startActiveSpan("middleware.onboarding", async (span) => {
     try {
-      ctx.state.onboarding = await getUserOnboarding(ctx.state.userId);
+      ctx.state.onboarding = await tracer.startActiveSpan(
+        "kv.getUserOnboarding",
+        async (span) => {
+          try {
+            return await getUserOnboarding(ctx.state.userId);
+          } finally {
+            span.end();
+          }
+        },
+      );
+
       return await ctx.next();
     } catch (err) {
       span.recordException(err as Error);

--- a/middleware/telemetry.ts
+++ b/middleware/telemetry.ts
@@ -1,0 +1,15 @@
+import { trace } from "@opentelemetry/api";
+
+import { define } from "#/core.ts";
+
+/**
+ * Annotates the active OTEL span with useful request attributes.
+ */
+export const telemetry = define.middleware((ctx) => {
+  const span = trace.getActiveSpan();
+
+  const ua = ctx.req.headers.get("user-agent");
+
+  if (ua) span?.setAttribute("http.user_agent", ua);
+  return ctx.next();
+});

--- a/middleware/theme.ts
+++ b/middleware/theme.ts
@@ -5,7 +5,17 @@ import { tracer } from "#/lib/telemetry.ts";
 export const theme = define.middleware((ctx) =>
   tracer.startActiveSpan("middleware.theme", async (span) => {
     try {
-      ctx.state.theme = (await getUserTheme(ctx.state.userId)) ?? "skub";
+      ctx.state.theme = await tracer.startActiveSpan(
+        "kv.getUserTheme",
+        async (span) => {
+          try {
+            return (await getUserTheme(ctx.state.userId)) ?? "skub";
+          } finally {
+            span.end();
+          }
+        },
+      );
+
       return await ctx.next();
     } catch (err) {
       span.recordException(err as Error);


### PR DESCRIPTION
Should get a better picture of middleware performance, and a nice userAgent property for spotting crawlers, bots
