### PR TITLE
Remove dialog from DOM when not open

### DIFF
--- a/islands/dialog.tsx
+++ b/islands/dialog.tsx
@@ -14,11 +14,14 @@ export function Dialog({ open, className, children, ...rest }: Props) {
     if (open) ref.current?.showModal();
   }, [open]);
 
+  // Remove from DOM if not open
+  if (!open) return null;
+
   return (
     <dialog
       ref={ref}
-      open={open}
       data-modal
+      open
       className={clsx(
         "m-auto rounded-cond-2 max-w-lg shadow-4 z-5",
         "lg:min-w-100",


### PR DESCRIPTION
Remove the dialog element from DOM when not open.
easier to read the DOM, avoid issues when programmatically closing (later PR)

## Demo

<!-- screenshots / screen recording here -->

**Quick regresh**

https://github.com/user-attachments/assets/78bb1ab2-ebcc-433f-8ef1-bf832a0e289f

