### PR TITLE
Exclude all query params from robots

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -38,7 +38,7 @@ User-agent: *
 Allow: /
 
 # Disallow crawling of puzzle pages with game state and hint endpoints
-Disallow: /puzzles/*?moves=*
+Disallow: /puzzles/*?*
 Disallow: /puzzles/*/hint
 Disallow: /puzzles/*/clone
 


### PR DESCRIPTION
Don't want any query params to be crawled, it's temporary important user state, not useful outside the context of a session
