### PR TITLE
Use ref callbacks for hooks

### DIFF
--- a/client/keyboard.ts
+++ b/client/keyboard.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 
 import type { Direction } from "#/game/types.ts";
 
@@ -10,28 +10,31 @@ type UseArrowKeysOptions = {
 export function useArrowKeys(
   { isEnabled, onArrowKey }: UseArrowKeysOptions,
 ) {
+  const onArrowKeyRef = useRef(onArrowKey);
+  onArrowKeyRef.current = onArrowKey;
+
   useEffect(() => {
     const handler = (event: KeyboardEvent) => {
       switch (event.key) {
         case "ArrowUp":
-          return onArrowKey("up");
+          return onArrowKeyRef.current("up");
         case "ArrowRight":
-          return onArrowKey("right");
+          return onArrowKeyRef.current("right");
         case "ArrowDown":
-          return onArrowKey("down");
+          return onArrowKeyRef.current("down");
         case "ArrowLeft":
-          return onArrowKey("left");
+          return onArrowKeyRef.current("left");
       }
     };
 
     if (isEnabled) {
-      self.addEventListener("keyup", handler);
+      globalThis.document.addEventListener("keyup", handler);
     }
 
     return () => {
-      self.removeEventListener("keyup", handler);
+      globalThis.document.removeEventListener("keyup", handler);
     };
-  }, [isEnabled, onArrowKey]);
+  }, [isEnabled]);
 }
 
 type useGameShortcutsOptions = {
@@ -76,10 +79,10 @@ export function useGameShortcuts(
       }
     };
 
-    self.addEventListener("keyup", handler);
+    globalThis.document.addEventListener("keyup", handler);
 
     return () => {
-      self.removeEventListener("keyup", handler);
+      globalThis.document.removeEventListener("keyup", handler);
     };
   }, [onSubmit, onUndo, onRedo, onReset]);
 }

--- a/client/moves.ts
+++ b/client/moves.ts
@@ -1,5 +1,4 @@
 import type { RefObject } from "preact";
-import { useCallback } from "preact/hooks";
 
 import { useArrowKeys } from "#/client/keyboard.ts";
 import { useSwipe } from "#/client/touch.ts";
@@ -28,16 +27,13 @@ export function useMoves(
   boardRef: RefObject<HTMLElement>,
   { pieces, active, onMove, isEnabled }: UseMoveOptions,
 ): void {
-  const onArrowKey = useCallback(
-    (direction: Direction) => {
-      if (!active) return;
+  const onArrowKey = (direction: Direction) => {
+    if (!active) return;
 
-      const boardWidth = boardRef.current?.getBoundingClientRect().width ?? 0;
-      const cellSize = boardWidth / 8;
-      onMove(active, { direction, cellSize, velocity: DEFAULT_VELOCITY });
-    },
-    [active, onMove, boardRef],
-  );
+    const boardWidth = boardRef.current?.getBoundingClientRect().width ?? 0;
+    const cellSize = boardWidth / 8;
+    onMove(active, { direction, cellSize, velocity: DEFAULT_VELOCITY });
+  };
 
   useArrowKeys({ onArrowKey, isEnabled });
 


### PR DESCRIPTION
Fixes a smaller issue where keyboard events would get continually attached and removed again, instead of just using whatever data is available

## Demo

https://github.com/user-attachments/assets/834625f4-7366-4d4b-b191-29323e92bfc6

