### PR TITLE
Fix deploy preview: fall back to SHA when ref is empty

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -23,7 +23,7 @@ jobs:
             --jq '.commit.message | split("\n") | .[0]')
 
           BODY=$(jq -n \
-            --arg ref "$DEPLOY_REF" \
+            --arg ref "${DEPLOY_REF:-$DEPLOY_SHA}" \
             --arg desc "$MSG" \
             '{ref: $ref, environment: "preview", auto_merge: false, required_contexts: [], description: $desc}')
 


### PR DESCRIPTION
Deno Deploy's repository_dispatch doesn't always populate git.ref. Use the commit SHA as fallback — GitHub's deployments API accepts it.

🤞 

<!-- spec:start -->
<!-- if a spec.md exists in this branch, it will be updated here automatically. delete this comment to skip. -->
<!-- spec:end -->
