### PR TITLE
Use PAT for deploy preview to trigger downstream workflows

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -37,4 +37,5 @@ jobs:
             -f state=success \
             -f environment_url="$PREVIEW_URL"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # TODO: Replace PAT with a GitHub App token for tighter scoping
+          GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}


### PR DESCRIPTION
GITHUB_TOKEN-created events don't trigger other workflows. Switch to a PAT (DEPLOY_TOKEN) so the deployment_status event reaches the e2e workflow.

<!-- spec:start -->
<!-- if a spec.md exists in this branch, it will be updated here automatically. delete this comment to skip. -->
<!-- spec:end -->

