### PR TITLE
Fix layout jump between home and other pages on lg

### DIFF
--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -72,6 +72,7 @@ export default define.page(
             "grow grid grid-cols-[minmax(var(--size-fluid-3),auto)_1fr_minmax(var(--size-fluid-3),auto)]",
             "sm:grid-cols-[minmax(var(--size-fluid-3),auto)_max-content_minmax(var(--size-fluid-3),auto)]",
             "grid-rows-[auto_auto_1fr_auto] place-items-[flex-end_center] gap-y-fl-3",
+            // 16 rem is the sidebar, 6rem is a min height on the first row
             "lg:grid-cols-[1fr_16rem] lg:grid-rows-[minmax(6rem,auto)_auto_1fr_auto] lg:content-center",
             "print:grid-cols-[1fr_max-content_1fr] print:grid-rows-[auto_1fr] print:gap-0",
           )}


### PR DESCRIPTION
The sidebar's "Inspired by" content on the home page made row 1 taller than on other pages, shifting the share/profile links. A 6rem min-height on the first grid row at lg keeps it stable.

<!-- spec:start -->
<!-- if a spec.md exists in this branch, it will be updated here automatically. delete this comment to skip. -->
<!-- spec:end -->

## Demo

Before

https://github.com/user-attachments/assets/946035e5-8b19-4474-85d4-0d5e8a25d6e7


After

https://github.com/user-attachments/assets/5c62cc8d-2f23-44d4-b1fa-bd62c0c73f63




<!-- screenshots / screen recording here -->
