### PR TITLE
Update tagline copy

### DIFF
--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -35,7 +35,7 @@ export default define.page(
           <meta property="og:title" content="Skub" />
           <meta
             property="og:description"
-            content="Slide pieces to reach the target. No stops, no turns. Fewest moves wins."
+            content="Slide the puck to the target. Fewest moves wins."
           />
           {ogSlug && (
             <meta

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -89,8 +89,7 @@ export default define.page<typeof handler>(function Home(ctx) {
           </h1>
 
           <p className="text-text-2">
-            Slide pieces to reach the target. No stops, no turns.<br />Fewest
-            moves wins.
+            Slide the puck to the target.<br />Fewest moves wins.
           </p>
         </div>
 


### PR DESCRIPTION
## Summary
- Replaces "Slide pieces to reach the target. No stops, no turns." with "Slide the puck to the target. Fewest moves wins."
- Updates both the visible home page tagline and the og:description meta tag
- Clearer (says "puck" not "pieces"), more concise (2 short lines that don't wrap awkwardly on mobile)

## Demo

https://github.com/user-attachments/assets/5a2aa00d-5f44-487c-a338-edfe49fa3c3a

## Test plan
- [x] Check home page on mobile — tagline should fit on 2 lines
- [x] Check og:description in page source


🤖 Generated with [Claude Code](https://claude.com/claude-code)