### PR TITLE
Add waitForLoadState to solveByClicking in puzzle page POM

### DIFF
--- a/routes/puzzles/[slug]/_e2e/puzzle-page.ts
+++ b/routes/puzzles/[slug]/_e2e/puzzle-page.ts
@@ -68,6 +68,10 @@ export class PuzzlePage {
   async solveByClicking() {
     const puzzle = await getPuzzle(this.currentSlug);
     if (!puzzle) throw new Error(`Puzzle not found: ${this.currentSlug}`);
+
+    // Wait for the dom to be fully loaded, as this relies on event listeners to attach.
+    await this.page.waitForLoadState("domcontentloaded");
+
     for (const move of solveSync(puzzle)) {
       await this.page.getByRole("link", {
         name: `at ${move[0].x},${move[0].y}`,


### PR DESCRIPTION
Matches the pattern already used in solveByKeyboard, prevents potential flakes when called right after a client-side transition, and aligns better with actual user experience.
Also could see some perf improvements.

