### PR TITLE
Use router replace on piece interaction and reset button

### DIFF
--- a/islands/board.tsx
+++ b/islands/board.tsx
@@ -339,7 +339,7 @@ function MoveGuide({ move, href, isHint }: MoveGuideProps) {
         }}
         aria-label={`move to ${target.x},${target.y}`}
         tabIndex={-1}
-        data-router="push"
+        data-router="replace"
       />
     </>
   );

--- a/islands/controls-panel.tsx
+++ b/islands/controls-panel.tsx
@@ -179,7 +179,7 @@ export function ControlsPanel(
             <a
               href={getResetHref(href.value)}
               className="bg-transparent"
-              data-router="push"
+              data-router="replace"
             >
               Start over
             </a>


### PR DESCRIPTION
After user feedback, use router replace for client side piece interaction and reset, so the browser "back" button sends the user back to before the current puzzle, and no longer works as an undo.

## Demo

**Before**

https://github.com/user-attachments/assets/912404d2-9805-4f42-bdc1-7041e0d86145

**After**

https://github.com/user-attachments/assets/95cc80d3-fe4f-4493-9be8-b71a91791775

