### PR TITLE
Updated tutorial UX

### DIFF
--- a/islands/solution-dialog.tsx
+++ b/islands/solution-dialog.tsx
@@ -95,7 +95,7 @@ export function SolutionDialog(
           <a
             href={getResetHref(href.value)}
           >
-            Try again
+            Play again
           </a>
         </div>
 
@@ -107,7 +107,7 @@ export function SolutionDialog(
         >
           {isSubmitting
             ? <Icon icon={Spinner} className="animate-spin" />
-            : "Claim your solve"}
+            : "Save"}
         </button>
       </div>
     </Dialog>

--- a/islands/solution-dialog.tsx
+++ b/islands/solution-dialog.tsx
@@ -52,8 +52,8 @@ export function SolutionDialog(
 
         <p>
           {savedName
-            ? "Claim your solve to see how others did it."
-            : "Pick a name and see how others did it."}
+            ? "Get your solve on the board."
+            : "Pick a name and get your solve on the board."}
         </p>
       </div>
 
@@ -97,17 +97,6 @@ export function SolutionDialog(
           >
             Try again
           </a>
-
-          <form method="dialog" className="inline">
-            <button
-              type="submit"
-              className="link p-0 bg-transparent"
-              formNoValidate
-              disabled={!hasSolution}
-            >
-              Close
-            </button>
-          </form>
         </div>
 
         <button

--- a/islands/tutorial-dialog.tsx
+++ b/islands/tutorial-dialog.tsx
@@ -2,7 +2,7 @@ import type { Signal } from "@preact/signals";
 import { clsx } from "clsx/lite";
 import { useMemo } from "preact/hooks";
 
-import { ArrowLeft, ArrowRight, Icon, X } from "#/components/icons.tsx";
+import { ArrowLeft, Icon, X } from "#/components/icons.tsx";
 import type { Solution } from "#/db/types.ts";
 import { getReplaySpeed } from "#/game/url.ts";
 import { Dialog } from "#/islands/dialog.tsx";
@@ -107,7 +107,6 @@ function TutorialWelcomeStep({ href, open }: TutorialStepProps) {
           autoFocus
         >
           How it works
-          <Icon icon={ArrowRight} />
         </a>
       </form>
     </>
@@ -148,7 +147,7 @@ function TutorialPiecesStep({ href }: TutorialStepProps) {
           data-router="push"
         >
           <Icon icon={ArrowLeft} />
-          Previous
+          Back
         </a>
 
         <a
@@ -172,16 +171,15 @@ function TutorialReplayStep({ href }: TutorialStepProps) {
   return (
     <>
       <div className="flex flex-col gap-fl-2 text-text-2">
-        <h1 className="text-fl-2 leading-tight text-text-1">
+        <h1 className="text-fl-2 leading-none text-text-1 text-pretty">
           That's one way to solve it
         </h1>
-        <p>
-          That's one way to solve it. <a href={reloadStep}>Show again</a>
-        </p>
 
         <p>
           Every puzzle has many solutions, each ranked by number of moves.<br />
-          Next up: the daily or a starter puzzle.
+        </p>
+        <p>
+          Next up: today's puzzle, or an easier starter.
         </p>
       </div>
 
@@ -198,7 +196,7 @@ function TutorialReplayStep({ href }: TutorialStepProps) {
           data-router="push"
         >
           <Icon icon={ArrowLeft} />
-          Previous
+          Back
         </a>
 
         <button type="submit" className="btn">
@@ -219,8 +217,10 @@ function TutorialSolveStep({ href }: TutorialStepProps) {
           You found a solution!
         </h1>
         <p>
-          Every puzzle has many solutions, each ranked by number of moves.<br />
-          Next up: the daily or a starter puzzle.
+          Every puzzle has many solutions, each ranked by number of moves.
+        </p>
+        <p>
+          Next up: today's puzzle, or an easier starter.
         </p>
       </div>
 
@@ -237,7 +237,7 @@ function TutorialSolveStep({ href }: TutorialStepProps) {
           data-router="push"
         >
           <Icon icon={ArrowLeft} />
-          Previous
+          Back
         </a>
 
         <button type="submit" className="btn">
@@ -295,7 +295,7 @@ function IconBlocker() {
 
 function IconDestination() {
   return (
-    <span className="inline-flex items-center justify-center w-5 h-5 border border-ui-1">
+    <span className="inline-flex items-center justify-center w-4 h-4 border border-ui-1 -mb-1">
       <Icon icon={X} className="text-ui-1 text-[1.3em]" />
     </span>
   );

--- a/islands/tutorial-dialog.tsx
+++ b/islands/tutorial-dialog.tsx
@@ -2,7 +2,7 @@ import type { Signal } from "@preact/signals";
 import { clsx } from "clsx/lite";
 import { useMemo } from "preact/hooks";
 
-import { Icon, X } from "#/components/icons.tsx";
+import { ArrowLeft, ArrowRight, Icon, X } from "#/components/icons.tsx";
 import type { Solution } from "#/db/types.ts";
 import { getReplaySpeed } from "#/game/url.ts";
 import { Dialog } from "#/islands/dialog.tsx";
@@ -79,8 +79,7 @@ function TutorialWelcomeStep({ href, open }: TutorialStepProps) {
         </h1>
 
         <p>
-          A tiny puzzle game where you slide pieces into walls and each other to
-          get the puck to the target — in as few moves as possible.
+          A sliding puzzle game inspired by the boardgame Ricochet Robots.
         </p>
 
         <p className="text-text-3 text-fl-min">
@@ -98,7 +97,7 @@ function TutorialWelcomeStep({ href, open }: TutorialStepProps) {
           className="btn mr-auto"
           disabled={!open}
         >
-          Dismiss
+          Home
         </button>
 
         <a
@@ -107,7 +106,8 @@ function TutorialWelcomeStep({ href, open }: TutorialStepProps) {
           data-router="push"
           autoFocus
         >
-          Next
+          How it works
+          <Icon icon={ArrowRight} />
         </a>
       </form>
     </>
@@ -127,16 +127,17 @@ function TutorialPiecesStep({ href }: TutorialStepProps) {
   return (
     <>
       <div className="flex flex-col gap-fl-2 text-text-2">
-        <h1 className="text-fl-2 leading-tight text-text-1">The pieces</h1>
+        <h1 className="text-fl-2 leading-tight text-text-1">How it works</h1>
         <p>
-          There are two pieces: the puck <IconPuck /> and the blocker{" "}
-          <IconBlocker />. Both slide until they hit each other or a
+          Meet the puck <IconPuck /> and the blocker{" "}
+          <IconBlocker />. They both slide until they hit each other or a
           wa<span className="text-ui-4">ll</span>.
         </p>
 
         <p>
-          Get the puck to stop on the target <IconDestination />{" "}
-          and you've found a solution.
+          Your goal: get the puck <IconPuck /> to stop <strong>exactly</strong>
+          {" "}
+          on the target <IconDestination />.
         </p>
       </div>
 
@@ -146,6 +147,7 @@ function TutorialPiecesStep({ href }: TutorialStepProps) {
           className="btn"
           data-router="push"
         >
+          <Icon icon={ArrowLeft} />
           Previous
         </a>
 
@@ -171,15 +173,15 @@ function TutorialReplayStep({ href }: TutorialStepProps) {
     <>
       <div className="flex flex-col gap-fl-2 text-text-2">
         <h1 className="text-fl-2 leading-tight text-text-1">
-          Finding a solution
+          That's one way to solve it
         </h1>
         <p>
           That's one way to solve it. <a href={reloadStep}>Show again</a>
         </p>
 
         <p>
-          Every puzzle has many solutions, each ranked by number of moves. A new
-          puzzle drops every day.
+          Every puzzle has many solutions, each ranked by number of moves.<br />
+          We've prepped both the daily and a starter puzzle for you.
         </p>
       </div>
 
@@ -195,6 +197,7 @@ function TutorialReplayStep({ href }: TutorialStepProps) {
           className="btn"
           data-router="push"
         >
+          <Icon icon={ArrowLeft} />
           Previous
         </a>
 

--- a/islands/tutorial-dialog.tsx
+++ b/islands/tutorial-dialog.tsx
@@ -163,10 +163,6 @@ function TutorialPiecesStep({ href }: TutorialStepProps) {
 
 function TutorialReplayStep({ href }: TutorialStepProps) {
   const prevStep = useMemo(() => getStepLink(href, "pieces"), [href]);
-  const reloadStep = useMemo(
-    () => getStepLink(href, "replay", { mode: "replay", replaySpeed: 0.667 }),
-    [href],
-  );
 
   return (
     <>

--- a/islands/tutorial-dialog.tsx
+++ b/islands/tutorial-dialog.tsx
@@ -181,7 +181,7 @@ function TutorialReplayStep({ href }: TutorialStepProps) {
 
         <p>
           Every puzzle has many solutions, each ranked by number of moves.<br />
-          We've prepped both the daily and a starter puzzle for you.
+          Next up: the daily or a starter puzzle.
         </p>
       </div>
 
@@ -202,7 +202,7 @@ function TutorialReplayStep({ href }: TutorialStepProps) {
         </a>
 
         <button type="submit" className="btn">
-          I'm ready
+          I'm ready!
         </button>
       </form>
     </>
@@ -219,8 +219,8 @@ function TutorialSolveStep({ href }: TutorialStepProps) {
           You found a solution!
         </h1>
         <p>
-          Every puzzle has many solutions, each ranked by number of moves.
-          Today's puzzle is waiting.
+          Every puzzle has many solutions, each ranked by number of moves.<br />
+          Next up: the daily or a starter puzzle.
         </p>
       </div>
 
@@ -236,11 +236,12 @@ function TutorialSolveStep({ href }: TutorialStepProps) {
           className="btn"
           data-router="push"
         >
+          <Icon icon={ArrowLeft} />
           Previous
         </a>
 
         <button type="submit" className="btn">
-          I'm ready
+          I'm ready!
         </button>
       </form>
     </>

--- a/routes/puzzles/[slug]/_e2e/puzzle-page.ts
+++ b/routes/puzzles/[slug]/_e2e/puzzle-page.ts
@@ -26,7 +26,7 @@ export class PuzzlePage {
       usernameInput: page.getByRole("textbox", { name: /username/i }),
       submitName: async (name: string) => {
         await page.getByRole("textbox", { name: /username/i }).fill(name);
-        await page.getByRole("button", { name: /Claim your solve/i }).click();
+        await page.getByRole("button", { name: /Save/i }).click();
         return new SolutionsPage(page);
       },
     };

--- a/routes/puzzles/tutorial/_e2e/tutorial-page.ts
+++ b/routes/puzzles/tutorial/_e2e/tutorial-page.ts
@@ -22,11 +22,13 @@ export class TutorialPage {
   }
 
   get piecesHeading() {
-    return this.page.getByRole("heading", { name: /the pieces/i });
+    return this.page.getByRole("heading", { name: /how it works/i });
   }
 
   get solutionHeading() {
-    return this.page.getByRole("heading", { name: /finding a solution/i });
+    return this.page.getByRole("heading", {
+      name: /that's one way to solve it/i,
+    });
   }
 
   get solvedHeading() {
@@ -34,7 +36,7 @@ export class TutorialPage {
   }
 
   async clickNext() {
-    await this.page.getByRole("link", { name: /next/i }).click();
+    await this.page.getByRole("link", { name: /how it works/i }).click();
     return this;
   }
 

--- a/spec.md
+++ b/spec.md
@@ -28,19 +28,29 @@ Previous/Next so navigation reads at a glance.
 - Heading: "Finding a solution" → "That's one way to solve it"
 - Body: mentions that both the daily and a starter puzzle are prepped for the user
 - Previous button gets a left-arrow icon
+- "I'm ready" → "I'm ready!"
+
+**Solved step**
+- Body: same "daily and starter puzzle prepped" line as the replay step
+- Previous button gets a left-arrow icon
+- "I'm ready" → "I'm ready!"
 
 ### Solution dialog (`islands/solution-dialog.tsx`)
 
 - Body copy: "Claim your solve to see how others did it." → "Get your solve on the board." (and the unnamed variant matches)
 - Removed the redundant "Close" button — "Try again" already covers the dismiss case
 
-## Follow-up
+## E2e updates
 
-- **e2e selector is stale**: `routes/puzzles/tutorial/_e2e/tutorial-page.ts:29`
-  still matches `/finding a solution/i`. Update to `/that's one way to solve it/i`
-  before the e2e suite runs.
+`routes/puzzles/tutorial/_e2e/tutorial-page.ts` matchers updated to track copy:
+- `piecesHeading` → `/how it works/i`
+- `solutionHeading` → `/that's one way to solve it/i`
+- `clickNext()` → `/how it works/i`
+
+`/i'm ready/i` substring-matches "I'm ready!" so no change needed there.
 
 ## Files
 
-- **modified** `islands/tutorial-dialog.tsx` — copy + arrow icons across all three steps
+- **modified** `islands/tutorial-dialog.tsx` — copy + arrow icons across all four steps
 - **modified** `islands/solution-dialog.tsx` — copy tweak, removed Close button
+- **modified** `routes/puzzles/tutorial/_e2e/tutorial-page.ts` — selectors track new copy

--- a/spec.md
+++ b/spec.md
@@ -1,105 +1,46 @@
-# Tutorial rework + skill level system
+# Tutorial UX copy + flow polish
 
 ## Problem
 
-The old onboarding was a single-state toggle (`new` → `done`) tied to puzzle-solving
-efficiency. First-time players got a tutorial, then immediately saw the daily puzzle
-with no scaffolding. There was no model for how capable a player actually is.
+The tutorial and solution dialog copy was wordy and didn't read well. Button
+labels were generic ("Dismiss", "Next") instead of describing what they do.
+Headings buried the key idea.
 
 ## Solution
 
-Replace the onboarding state machine with a **skill level** on the user record and a
-sequence of onboarding puzzles ordered by `onboardingLevel`. Skill is earned through
-play, not just by completing steps.
+Tighten the copy in the tutorial dialog and solution dialog. Replace generic
+button labels with action-oriented ones, and add directional arrow icons to
+Previous/Next so navigation reads at a glance.
 
-### Skill level (`User.skillLevel: SkillLevel | null`)
+### Tutorial dialog (`islands/tutorial-dialog.tsx`)
 
-| Level | Earned by | Home page shows |
-|---|---|---|
-| `null` | Default (unknown) | Tutorial CTA |
-| `"beginner"` | Completing tutorial, or first puzzle solve (skip path) | Next unsolved onboarding puzzle, or random if all done |
-| `"intermediate"` | Medium solved within 1.33× optimal, OR easy solved perfectly with `minMoves > 5` | Random puzzle |
-| `"expert"` | Medium or hard puzzle solved perfectly | Random puzzle |
+**Welcome step**
+- Body: shortened to "A sliding puzzle game inspired by the boardgame Ricochet Robots."
+- "Dismiss" → "Home"
+- "Next" → "How it works" + right-arrow icon
 
-Promotions only move upward. `trackSkillLevelUp` fires (with `$set: { skill_level }` for PostHog person profile) on intermediate/expert promotions. `trackTutorialCompleted` sets `$set: { skill_level: "beginner" }` on the profile.
+**Pieces step**
+- Heading: "The pieces" → "How it works"
+- Body: rewritten to emphasise the goal — puck must stop **exactly** on the target
+- Previous button gets a left-arrow icon
 
-### Onboarding puzzles
+**Replay step**
+- Heading: "Finding a solution" → "That's one way to solve it"
+- Body: mentions that both the daily and a starter puzzle are prepped for the user
+- Previous button gets a left-arrow icon
 
-Puzzles tagged with `onboardingLevel: number` in frontmatter are filtered from all regular listings. The home page shows the first unsolved one (level > 1) to `"beginner"` users.
+### Solution dialog (`islands/solution-dialog.tsx`)
 
-| Level | Slug | Tagline |
-|---|---|---|
-| 1 | `tutorial` | — (separate route) |
-| 2 | `lars` | "Starter puzzle" |
-| 3 | `lone` | "Quick puzzle" |
+- Body copy: "Claim your solve to see how others did it." → "Get your solve on the board." (and the unnamed variant matches)
+- Removed the redundant "Close" button — "Try again" already covers the dismiss case
 
-### Loader (`game/loader.ts`)
+## Follow-up
 
-- `Puzzle.number` is now optional — onboarding puzzles have no number
-- All listing functions (`getAvailableEntries`, `getFutureEntries`, `getRandomPuzzle`, etc.) filter `!entry.onboardingLevel`
-- `getTutorialPuzzle()` — fetch level 1 puzzle
-- `getOnboardingPuzzle({ excludeSlugs })` — next unsolved puzzle at level > 1, or null if all solved
-
-### Home page (`routes/index.tsx`)
-
-- `skillLevel === null` → tutorial CTA (no puzzle loaded)
-- `skillLevel === "beginner"` → `getOnboardingPuzzle({ excludeSlugs: solvedSlugs })`; falls through to random if null
-- `skillLevel !== null && !== "beginner"` → random puzzle (difficulty filtered: `expert` gets easy/medium/hard, others get easy/medium)
-- `onboardingPuzzle` and `randomPuzzle` are mutually exclusive — random only loaded when onboarding is null
-
-### Puzzle solve handler (`routes/puzzles/[slug]/index.tsx`)
-
-Skill promotion is assessed via `assessSkillLevel(puzzle, moves, { current })` in `game/skill.ts` — idempotent, returns the current level if no promotion applies. Called on every new solve; result compared against current level to detect a change.
-
-Promotion rules (first match wins):
-
-1. Medium/hard + `moves === minMoves` + not already expert → `"expert"` + `trackSkillLevelUp`
-2. Medium + `moves ≤ minMoves * 1.33` + not intermediate/expert → `"intermediate"` + `trackSkillLevelUp`
-3. Easy + `moves === minMoves` + `minMoves > 5` + not intermediate/expert → `"intermediate"` + `trackSkillLevelUp`
-4. `skillLevel === null` → `"beginner"` (silent, skip-tutorial path)
-
-### Tutorial route (`routes/puzzles/tutorial/index.tsx`)
-
-- Loads puzzle via `getTutorialPuzzle()`
-- POST: promotes user to `"beginner"` + fires `trackTutorialCompleted`
-- "Rather watch?" extracted to `TutorialWatchButton` island (renders in solve mode)
-
-### Tracking (`lib/tracking.ts`)
-
-- `trackTutorialCompleted` — sets `$set: { skill_level: "beginner" }` on PostHog profile
-- `trackSkillLevelUp` — fires on intermediate/expert promotions, sets `$set: { skill_level }` on profile; includes `puzzle_difficulty`, `puzzle_min_moves`, `game_moves`, `skill_level`
-
-### Migration (`routes/api/migrate-skill-level.ts`)
-
-`GET /api/migrate-skill-level?secret=<MIGRATE_SECRET>` — assesses each user's skill level from their solution history using the same promotion rules, skips users already with `skillLevel`.
-
-### Minor
-
-- `puzzle-card.tsx`, `[slug]/index.tsx`, `solutions/`, `preview/`, `share.ts`: `puzzle.number` guarded (undefined-safe)
-- `routes/_app.tsx`: `"daily"` removed from OG image exclusion list
-- `routes/puzzles/index.tsx`: hardcoded `"tutorial"` exclusion removed (loader filter handles it)
+- **e2e selector is stale**: `routes/puzzles/tutorial/_e2e/tutorial-page.ts:29`
+  still matches `/finding a solution/i`. Update to `/that's one way to solve it/i`
+  before the e2e suite runs.
 
 ## Files
 
-- **modified** `game/types.ts` — `Onboarding` → `SkillLevel`, `Puzzle.onboarding` → `onboardingLevel?: number`
-- **modified** `db/types.ts` — `User.onboarding` → `skillLevel: SkillLevel | null`
-- **modified** `middleware/user.ts` — new user defaults to `skillLevel: null`
-- **modified** `game/loader.ts` — `onboardingLevel` filtering, `getTutorialPuzzle()`, `getOnboardingPuzzle({ excludeSlugs })`
-- **modified** `lib/manifest.ts` — `onboardingLevel` field in manifest
-- **modified** `lib/tracking.ts` — `trackTutorialCompleted` (profile set), `trackSkillLevelUp`
-- **modified** `routes/index.tsx` — skill-level-based home page branching
-- **modified** `routes/puzzles/[slug]/index.tsx` — skill promotion logic
-- **modified** `routes/puzzles/tutorial/index.tsx` — `getTutorialPuzzle()`, beginner promotion, `TutorialWatchButton`
-- **modified** `routes/puzzles/preview/index.tsx` — `skillLevel` prop on `ControlsPanel`
-- **modified** `routes/puzzles/index.tsx` — removed hardcoded tutorial exclusion
-- **modified** `routes/_app.tsx` — OG exclusion list
-- **deleted** `routes/api/migrate-user.ts` — removed (no longer needed)
-- **modified** `routes/api/e2e/users/index.ts` — `skillLevel` default
-- **modified** `islands/controls-panel.tsx` — `onboarding` → `skillLevel`, hint logic updated
-- **modified** `components/puzzle-card.tsx` — null-safe number
-- **added** `components/tutorial-watch-button.tsx` — "Rather watch?" island
-- **added** `static/puzzles/lars.md` — onboardingLevel 2, starter puzzle
-- **added** `static/puzzles/lone.md` — onboardingLevel 3, quick puzzle
-- **added** `routes/api/migrate-skill-level.ts` — skill level migration from solution history
-- **added** `game/skill.ts` — `assessSkillLevel(puzzle, moves, { current })` — idempotent skill assessment
-- **added** `game/skill_test.ts` — unit tests for all promotion rules and idempotency
+- **modified** `islands/tutorial-dialog.tsx` — copy + arrow icons across all three steps
+- **modified** `islands/solution-dialog.tsx` — copy tweak, removed Close button


### PR DESCRIPTION
<!-- spec:start -->
# Tutorial UX copy + flow polish

## Problem

The tutorial and solution dialog copy was wordy and didn't read well. Button
labels were generic ("Dismiss", "Next") instead of describing what they do.
Headings buried the key idea.

## Solution

Tighten the copy in the tutorial dialog and solution dialog. Replace generic
button labels with action-oriented ones, and add directional arrow icons to
Previous/Next so navigation reads at a glance.

### Tutorial dialog (`islands/tutorial-dialog.tsx`)

**Welcome step**
- Body: shortened to "A sliding puzzle game inspired by the boardgame Ricochet Robots."
- "Dismiss" → "Home"
- "Next" → "How it works" + right-arrow icon

**Pieces step**
- Heading: "The pieces" → "How it works"
- Body: rewritten to emphasise the goal — puck must stop **exactly** on the target
- Previous button gets a left-arrow icon

**Replay step**
- Heading: "Finding a solution" → "That's one way to solve it"
- Body: mentions that both the daily and a starter puzzle are prepped for the user
- Previous button gets a left-arrow icon
- "I'm ready" → "I'm ready!"

**Solved step**
- Body: same "daily and starter puzzle prepped" line as the replay step
- Previous button gets a left-arrow icon
- "I'm ready" → "I'm ready!"

### Solution dialog (`islands/solution-dialog.tsx`)

- Body copy: "Claim your solve to see how others did it." → "Get your solve on the board." (and the unnamed variant matches)
- Removed the redundant "Close" button — "Try again" already covers the dismiss case

## E2e updates

`routes/puzzles/tutorial/_e2e/tutorial-page.ts` matchers updated to track copy:
- `piecesHeading` → `/how it works/i`
- `solutionHeading` → `/that's one way to solve it/i`
- `clickNext()` → `/how it works/i`

`/i'm ready/i` substring-matches "I'm ready!" so no change needed there.

## Files

- **modified** `islands/tutorial-dialog.tsx` — copy + arrow icons across all four steps
- **modified** `islands/solution-dialog.tsx` — copy tweak, removed Close button
- **modified** `routes/puzzles/tutorial/_e2e/tutorial-page.ts` — selectors track new copy
<!-- spec:end -->

## Demo

<!-- screenshots / screen recording here -->

https://github.com/user-attachments/assets/9b499ef7-ea81-4b1d-bde8-6305c26373c2
