### PR TITLE
Puzzle guards, no more future direct access, cheats

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,6 +64,9 @@ jobs:
           fetch-depth: 0
 
       - uses: denoland/setup-deno@v2
+        with:
+          # 2.7.12 fails, issue filed
+          deno-version: 2.7.11
 
       - name: Fetch PR description
         id: pr

--- a/game/loader.ts
+++ b/game/loader.ts
@@ -41,7 +41,7 @@ export async function getAvailableEntries() {
   const manifest = await getPuzzleManifest();
 
   return manifest
-    .filter((entry) => !entry.onboardingLevel)
+    .filter((entry) => !entry.hidden)
     .filter((entry) => (entry.number ?? 0) <= dayOfYear);
 }
 
@@ -55,7 +55,7 @@ export async function getFutureEntries() {
   const manifest = await getPuzzleManifest();
 
   return manifest
-    .filter((entry) => !entry.onboardingLevel)
+    .filter((entry) => !entry.hidden)
     .filter((entry) => (entry.number ?? 0) > dayOfYear);
 }
 

--- a/game/types.ts
+++ b/game/types.ts
@@ -42,6 +42,7 @@ export type Puzzle = {
   difficulty: Difficulty;
   minMoves: number;
   onboardingLevel?: number;
+  hidden?: boolean;
 };
 
 // Lightweight puzzle entry used in the manifest index
@@ -54,6 +55,7 @@ export type PuzzleManifestEntry = Pick<
   | "minMoves"
   | "difficulty"
   | "onboardingLevel"
+  | "hidden"
 >;
 
 // Tracks current pagination position and total counts

--- a/islands/controls-panel.tsx
+++ b/islands/controls-panel.tsx
@@ -158,8 +158,16 @@ export function ControlsPanel(
             This is slightly expensive, so needs to be on demand, not optimistic.
           */
             }
-            {puzzle.value.slug !== "preview"
+            {puzzle.value.slug === "preview" && isDev
               ? (
+                <a
+                  href={getSolveHref(href.value)}
+                  className="noscript:hidden"
+                >
+                  Solve
+                </a>
+              )
+              : (
                 <a
                   href={hintDisabled ? "#" : getHintHref(href.value)}
                   aria-disabled={hintDisabled ? true : undefined}
@@ -173,14 +181,6 @@ export function ControlsPanel(
                     : puzzle.value.difficulty === "easy"
                     ? "Hints used"
                     : "Hint used"}
-                </a>
-              )
-              : (
-                <a
-                  href={getSolveHref(href.value)}
-                  className="noscript:hidden"
-                >
-                  Solve
                 </a>
               )}
 

--- a/lib/manifest.ts
+++ b/lib/manifest.ts
@@ -27,6 +27,7 @@ export async function updateManifest() {
         difficulty: attrs.difficulty,
         minMoves: attrs.minMoves,
         onboardingLevel: attrs.onboardingLevel,
+        hidden: attrs.hidden,
       });
     }
   }

--- a/routes/puzzles/[slug]/_middleware.ts
+++ b/routes/puzzles/[slug]/_middleware.ts
@@ -1,0 +1,31 @@
+import { HttpError } from "fresh";
+
+import { define } from "#/core.ts";
+import { getDayOfYear } from "#/game/date.ts";
+import { getPuzzle } from "#/game/loader.ts";
+import { isDev } from "#/lib/env.ts";
+
+/**
+ * Guards all [slug] routes against premature access.
+ * Returns 404 for puzzles with a number beyond today's day-of-year.
+ * Dev always bypasses the guard.
+ */
+export const handler = define.middleware(async (ctx) => {
+  if (isDev) return ctx.next();
+
+  const { slug } = ctx.params;
+  const puzzle = await getPuzzle(slug);
+
+  if (!puzzle) {
+    throw new HttpError(404, `Unable to find puzzle with slug: ${slug}`);
+  }
+
+  if (puzzle.number) {
+    const dayOfYear = getDayOfYear(new Date(Date.now()));
+    if (puzzle.number > dayOfYear) {
+      throw new HttpError(404, `Unable to find puzzle with slug: ${slug}`);
+    }
+  }
+
+  return ctx.next();
+});

--- a/routes/puzzles/[slug]/_middleware.ts
+++ b/routes/puzzles/[slug]/_middleware.ts
@@ -10,6 +10,11 @@ import { isDev } from "#/lib/env.ts";
  * Returns 404 for puzzles with a number beyond today's day-of-year.
  * Dev always bypasses the guard.
  */
+// TODO: use the cached manifest (getPuzzleManifest) instead of getPuzzle —
+// getPuzzle re-reads and re-parses the .md file on every request, and most
+// [slug] handlers call it again themselves, so the middleware currently
+// doubles the per-request cost. The manifest has slug + number + hidden,
+// which is all the guard needs.
 export const handler = define.middleware(async (ctx) => {
   if (isDev) return ctx.next();
 

--- a/routes/puzzles/[slug]/index.tsx
+++ b/routes/puzzles/[slug]/index.tsx
@@ -26,7 +26,7 @@ import { ControlsPanel } from "#/islands/controls-panel.tsx";
 import { DifficultyBadge } from "#/islands/difficulty-badge.tsx";
 import { HintDialog } from "#/islands/hint-dialog.tsx";
 import { SolutionDialog } from "#/islands/solution-dialog.tsx";
-import { SolveDialog } from "#/islands/solve-dialog.tsx";
+
 import { isDev } from "#/lib/env.ts";
 import { withSpan } from "#/lib/tracing.ts";
 import { trackPuzzleSolved, trackSkillLevelUp } from "#/lib/tracking.ts";
@@ -209,7 +209,7 @@ export default define.page<typeof handler>(function PuzzleDetails(props) {
       </a>
 
       <HintDialog puzzle={puzzle} href={href} />
-      <SolveDialog puzzle={puzzle} href={href} />
+
 
       <SolutionDialog
         href={href}

--- a/routes/puzzles/[slug]/index.tsx
+++ b/routes/puzzles/[slug]/index.tsx
@@ -26,7 +26,6 @@ import { ControlsPanel } from "#/islands/controls-panel.tsx";
 import { DifficultyBadge } from "#/islands/difficulty-badge.tsx";
 import { HintDialog } from "#/islands/hint-dialog.tsx";
 import { SolutionDialog } from "#/islands/solution-dialog.tsx";
-
 import { isDev } from "#/lib/env.ts";
 import { withSpan } from "#/lib/tracing.ts";
 import { trackPuzzleSolved, trackSkillLevelUp } from "#/lib/tracking.ts";
@@ -209,7 +208,6 @@ export default define.page<typeof handler>(function PuzzleDetails(props) {
       </a>
 
       <HintDialog puzzle={puzzle} href={href} />
-
 
       <SolutionDialog
         href={href}

--- a/routes/puzzles/preview/index.tsx
+++ b/routes/puzzles/preview/index.tsx
@@ -82,7 +82,7 @@ export default define.page<typeof handler>(function PreviewPuzzle(props) {
         {printUrl}
       </a>
 
-      <SolveDialog puzzle={puzzle} href={href} />
+      {isDev && <SolveDialog puzzle={puzzle} href={href} />}
     </>
   );
 });

--- a/routes/puzzles/tutorial/index.tsx
+++ b/routes/puzzles/tutorial/index.tsx
@@ -17,7 +17,7 @@ import { AutoPostSolution } from "#/islands/auto-post-solution.tsx";
 import Board from "#/islands/board.tsx";
 import { ControlsPanel } from "#/islands/controls-panel.tsx";
 import { HintDialog } from "#/islands/hint-dialog.tsx";
-import { SolveDialog } from "#/islands/solve-dialog.tsx";
+
 import { TutorialDialog } from "#/islands/tutorial-dialog.tsx";
 import { isDev } from "#/lib/env.ts";
 import { trackTutorialCompleted } from "#/lib/tracking.ts";
@@ -194,7 +194,7 @@ export default define.page<typeof handler>(function PuzzleTutorial(props) {
       />
 
       <HintDialog puzzle={puzzle} href={href} />
-      <SolveDialog puzzle={puzzle} href={href} />
+
 
       <TutorialDialog
         href={href}

--- a/routes/puzzles/tutorial/index.tsx
+++ b/routes/puzzles/tutorial/index.tsx
@@ -17,7 +17,6 @@ import { AutoPostSolution } from "#/islands/auto-post-solution.tsx";
 import Board from "#/islands/board.tsx";
 import { ControlsPanel } from "#/islands/controls-panel.tsx";
 import { HintDialog } from "#/islands/hint-dialog.tsx";
-
 import { TutorialDialog } from "#/islands/tutorial-dialog.tsx";
 import { isDev } from "#/lib/env.ts";
 import { trackTutorialCompleted } from "#/lib/tracking.ts";
@@ -194,7 +193,6 @@ export default define.page<typeof handler>(function PuzzleTutorial(props) {
       />
 
       <HintDialog puzzle={puzzle} href={href} />
-
 
       <TutorialDialog
         href={href}

--- a/spec.md
+++ b/spec.md
@@ -37,9 +37,9 @@ Covers all `[slug]` routes in one place — no inline checks needed.
 
 ### Solver dialog
 
-`SolveDialog` island gated behind `isDev` so it only ships in local dev:
-- `routes/puzzles/[slug]/index.tsx`
-- `routes/puzzles/tutorial/index.tsx`
+`SolveDialog` removed from puzzle and tutorial routes. On preview, gated
+behind `isDev` — the editor stays open for showcasing/collab, but the BFS
+solver is a design tool, not a collaboration feature.
 
 ## Files
 
@@ -50,5 +50,6 @@ Covers all `[slug]` routes in one place — no inline checks needed.
 - **modified** `static/puzzles/lars.md` — `hidden: true`
 - **modified** `static/puzzles/lone.md` — `hidden: true`
 - **added** `routes/puzzles/[slug]/_middleware.ts` — future puzzle guard
-- **modified** `routes/puzzles/[slug]/index.tsx` — solver gated behind isDev
-- **modified** `routes/puzzles/tutorial/index.tsx` — solver gated behind isDev
+- **modified** `routes/puzzles/[slug]/index.tsx` — removed SolveDialog
+- **modified** `routes/puzzles/tutorial/index.tsx` — removed SolveDialog
+- **modified** `routes/puzzles/preview/index.tsx` — SolveDialog gated behind isDev

--- a/spec.md
+++ b/spec.md
@@ -1,56 +1,54 @@
-# Tutorial UX copy + flow polish
+# Guard future puzzles and dev-only solver
 
 ## Problem
 
-The tutorial and solution dialog copy was wordy and didn't read well. Button
-labels were generic ("Dismiss", "Next") instead of describing what they do.
-Headings buried the key idea.
+Knowing a puzzle slug lets you play ahead — future puzzles are loadable by
+direct URL. The BFS solver dialog is also available in production, making it
+trivial to cheat.
+
+Additionally, listing exclusion is inferred from `onboardingLevel` which
+doesn't generalise — the upcoming endgame puzzle (Loke) needs exclusion too
+but isn't onboarding.
 
 ## Solution
 
-Tighten the copy in the tutorial dialog and solution dialog. Replace generic
-button labels with action-oriented ones, and add directional arrow icons to
-Previous/Next so navigation reads at a glance.
+### `hidden` flag
 
-### Tutorial dialog (`islands/tutorial-dialog.tsx`)
+Add `hidden?: boolean` to puzzle frontmatter and manifest. Replaces the
+`!entry.onboardingLevel` filter in `getAvailableEntries()` and
+`getFutureEntries()` with `!entry.hidden`.
 
-**Welcome step**
-- Body: shortened to "A sliding puzzle game inspired by the boardgame Ricochet Robots."
-- "Dismiss" → "Home"
-- "Next" → "How it works" + right-arrow icon
+`onboardingLevel` stays for ordering the onboarding sequence — `hidden`
+takes over the "should this appear in listings" concern.
 
-**Pieces step**
-- Heading: "The pieces" → "How it works"
-- Body: rewritten to emphasise the goal — puck must stop **exactly** on the target
-- Previous button gets a left-arrow icon
+Puzzles with `hidden: true`:
+- `tutorial.md` (onboarding level 1)
+- `lars.md` (onboarding level 2)
+- `lone.md` (onboarding level 3)
 
-**Replay step**
-- Heading: "Finding a solution" → "That's one way to solve it"
-- Body: mentions that both the daily and a starter puzzle are prepped for the user
-- Previous button gets a left-arrow icon
-- "I'm ready" → "I'm ready!"
+### Future puzzle guard
 
-**Solved step**
-- Body: same "daily and starter puzzle prepped" line as the replay step
-- Previous button gets a left-arrow icon
-- "I'm ready" → "I'm ready!"
+Middleware at `routes/puzzles/[slug]/_middleware.ts` — runs before all child
+routes. Loads the puzzle by slug, returns 404 if the puzzle's number is beyond
+today's day-of-year. Numberless puzzles (onboarding, endgame) are always
+allowed. Dev bypasses the guard entirely.
 
-### Solution dialog (`islands/solution-dialog.tsx`)
+Covers all `[slug]` routes in one place — no inline checks needed.
 
-- Body copy: "Claim your solve to see how others did it." → "Get your solve on the board." (and the unnamed variant matches)
-- Removed the redundant "Close" button — "Try again" already covers the dismiss case
+### Solver dialog
 
-## E2e updates
-
-`routes/puzzles/tutorial/_e2e/tutorial-page.ts` matchers updated to track copy:
-- `piecesHeading` → `/how it works/i`
-- `solutionHeading` → `/that's one way to solve it/i`
-- `clickNext()` → `/how it works/i`
-
-`/i'm ready/i` substring-matches "I'm ready!" so no change needed there.
+`SolveDialog` island gated behind `isDev` so it only ships in local dev:
+- `routes/puzzles/[slug]/index.tsx`
+- `routes/puzzles/tutorial/index.tsx`
 
 ## Files
 
-- **modified** `islands/tutorial-dialog.tsx` — copy + arrow icons across all four steps
-- **modified** `islands/solution-dialog.tsx` — copy tweak, removed Close button
-- **modified** `routes/puzzles/tutorial/_e2e/tutorial-page.ts` — selectors track new copy
+- **modified** `game/types.ts` — `hidden?: boolean` on `Puzzle` and `PuzzleManifestEntry`
+- **modified** `game/loader.ts` — listing filters use `!entry.hidden`
+- **modified** `lib/manifest.ts` — include `hidden` in manifest generation
+- **modified** `static/puzzles/tutorial.md` — `hidden: true`
+- **modified** `static/puzzles/lars.md` — `hidden: true`
+- **modified** `static/puzzles/lone.md` — `hidden: true`
+- **added** `routes/puzzles/[slug]/_middleware.ts` — future puzzle guard
+- **modified** `routes/puzzles/[slug]/index.tsx` — solver gated behind isDev
+- **modified** `routes/puzzles/tutorial/index.tsx` — solver gated behind isDev

--- a/static/puzzles/lars.md
+++ b/static/puzzles/lars.md
@@ -5,6 +5,7 @@ createdAt: 2026-04-06T11:55:36.751Z
 difficulty: easy
 minMoves: 4
 onboardingLevel: 2
+hidden: true
 ---
 
 ```

--- a/static/puzzles/lone.md
+++ b/static/puzzles/lone.md
@@ -5,6 +5,7 @@ createdAt: 2026-04-06T12:07:27.971Z
 difficulty: easy
 minMoves: 5
 onboardingLevel: 3
+hidden: true
 ---
 
 ```

--- a/static/puzzles/tutorial.md
+++ b/static/puzzles/tutorial.md
@@ -5,6 +5,7 @@ createdAt: 2026-04-06T09:47:05.173Z
 difficulty: easy
 minMoves: 3
 onboardingLevel: 1
+hidden: true
 ---
 
 ```


### PR DESCRIPTION
<!-- spec:start -->
# Guard future puzzles and dev-only solver

## Problem

Knowing a puzzle slug lets you play ahead — future puzzles are loadable by
direct URL. The BFS solver dialog is also available in production, making it
trivial to cheat.

Additionally, listing exclusion is inferred from `onboardingLevel` which
doesn't generalise — the upcoming endgame puzzle (Loke) needs exclusion too
but isn't onboarding.

## Solution

### `hidden` flag

Add `hidden?: boolean` to puzzle frontmatter and manifest. Replaces the
`!entry.onboardingLevel` filter in `getAvailableEntries()` and
`getFutureEntries()` with `!entry.hidden`.

`onboardingLevel` stays for ordering the onboarding sequence — `hidden`
takes over the "should this appear in listings" concern.

Puzzles with `hidden: true`:
- `tutorial.md` (onboarding level 1)
- `lars.md` (onboarding level 2)
- `lone.md` (onboarding level 3)

### Future puzzle guard

Middleware at `routes/puzzles/[slug]/_middleware.ts` — runs before all child
routes. Loads the puzzle by slug, returns 404 if the puzzle's number is beyond
today's day-of-year. Numberless puzzles (onboarding, endgame) are always
allowed. Dev bypasses the guard entirely.

Covers all `[slug]` routes in one place — no inline checks needed.

### Solver dialog

`SolveDialog` removed from puzzle and tutorial routes. On preview, gated
behind `isDev` — the editor stays open for showcasing/collab, but the BFS
solver is a design tool, not a collaboration feature.

## Files

- **modified** `game/types.ts` — `hidden?: boolean` on `Puzzle` and `PuzzleManifestEntry`
- **modified** `game/loader.ts` — listing filters use `!entry.hidden`
- **modified** `lib/manifest.ts` — include `hidden` in manifest generation
- **modified** `static/puzzles/tutorial.md` — `hidden: true`
- **modified** `static/puzzles/lars.md` — `hidden: true`
- **modified** `static/puzzles/lone.md` — `hidden: true`
- **added** `routes/puzzles/[slug]/_middleware.ts` — future puzzle guard
- **modified** `routes/puzzles/[slug]/index.tsx` — removed SolveDialog
- **modified** `routes/puzzles/tutorial/index.tsx` — removed SolveDialog
- **modified** `routes/puzzles/preview/index.tsx` — SolveDialog gated behind isDev
<!-- spec:end -->

## Demo

<!-- screenshots / screen recording here -->

https://github.com/user-attachments/assets/300ee366-baf4-4e89-9d36-3af1ba7192cf


https://github.com/user-attachments/assets/5a01c232-dca4-4f80-990e-c5bb85731906
