### PR TITLE
Add helper bot for archive-spec task

### DIFF
--- a/.github/workflows/archive-spec.yml
+++ b/.github/workflows/archive-spec.yml
@@ -10,10 +10,17 @@ on:
 jobs:
   archive:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
+      - name: Generate skub-helper token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SKUB_HELPER_APP_ID }}
+          private-key: ${{ secrets.SKUB_HELPER_APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Get branch name from merge commit
         id: branch


### PR DESCRIPTION
Permissions issues on github are never fun, let's add a helper bot to get rid of this once and for all.