### PR TITLE
Better tutorial / nudges / affordance hints

### DIFF
--- a/components/tutorial-nudge.tsx
+++ b/components/tutorial-nudge.tsx
@@ -15,8 +15,8 @@ export function TutorialNudge({ className }: Props) {
       )}
     >
       <p className="gap-1 min-w-[16ch] text-center leading-snug">
-        Tip: use blockers <IconBlocker /> to stop the puck <IconPuck />{" "}
-        mid-slide
+        Tip: click and move blockers <IconBlocker /> to stop the puck{" "}
+        <IconPuck /> mid-slide
       </p>
 
       <a href="/puzzles/tutorial" className="btn">

--- a/islands/board.tsx
+++ b/islands/board.tsx
@@ -1,6 +1,6 @@
 import type { Signal } from "@preact/signals";
 import { clsx } from "clsx/lite";
-import { useCallback, useMemo, useRef } from "preact/hooks";
+import { useCallback, useMemo, useRef, useState } from "preact/hooks";
 
 import { useRouter } from "./router.tsx";
 import { useMoves } from "#/client/moves.ts";
@@ -33,11 +33,12 @@ type BoardProps = {
   href: Signal<string>;
   puzzle: Signal<Puzzle>;
   mode: Signal<"editor" | "replay" | "solve" | "readonly">;
+  isNew?: boolean;
   className?: string;
 };
 
 export default function Board(
-  { href, puzzle, mode, className }: BoardProps,
+  { href, puzzle, mode, isNew = false, className }: BoardProps,
 ) {
   const swipeRegionRef = useRef<HTMLDivElement>(null);
   const boardRef = useRef<HTMLDivElement>(null);
@@ -82,6 +83,8 @@ export default function Board(
     () => getReplaySpeed(href.value) ?? 1,
     [href.value],
   );
+
+  const [wiggle, setWiggle] = useState({ puck: isNew, blocker: isNew });
 
   const onMove = useCallback(
     (src: Position, opts: {
@@ -194,9 +197,11 @@ export default function Board(
             id={getPieceId(piece, idx)}
             isActive={state.active && isPositionSame(piece, state.active)}
             isReadonly={mode.value === "replay" || mode.value === "editor"}
+            wiggle={mode.value === "solve" && wiggle[piece.type]}
             onFocus={(event) => {
               const href = (event.target as HTMLAnchorElement).href;
               updateLocation(href, { replace: true });
+              setWiggle((val) => ({ ...val, [piece.type]: false }));
             }}
           />
         ))}
@@ -229,8 +234,8 @@ function BoardWall({ x, y, orientation }: Wall) {
         "place-self-start col-[calc(var(--x)+1)] row-[calc(var(--y)+1)] w-full",
         "border-ui-4 aspect-square pointer-events-none",
         orientation === "vertical"
-          ? "border-l-[3px] -ml-1"
-          : "border-t-[3px] -mt-1",
+          ? "border-l-[3px] -ml-[3.5px]"
+          : "border-t-[3px] -mt-[3.5px]",
       )}
       style={{
         "--x": x,
@@ -353,11 +358,13 @@ type BoardPieceProps = {
   type: "puck" | "blocker";
   isActive?: boolean;
   isReadonly?: boolean;
+  wiggle?: boolean;
   onFocus: (event: FocusEvent) => void;
 };
 
 function BoardPiece(
-  { x, y, id, href, type, isReadonly, isActive, onFocus }: BoardPieceProps,
+  { x, y, id, href, type, isReadonly, isActive, wiggle, onFocus }:
+    BoardPieceProps,
 ) {
   return (
     <a
@@ -390,6 +397,8 @@ function BoardPiece(
           "w-full h-full",
           type === "puck" && "bg-ui-2 rounded-round",
           type === "blocker" && "bg-ui-3 rounded-1",
+          wiggle && type === "puck" && "pulse-puck",
+          wiggle && type === "blocker" && "jiggle",
         )}
       />
     </a>

--- a/islands/tutorial-dialog.tsx
+++ b/islands/tutorial-dialog.tsx
@@ -128,16 +128,20 @@ function TutorialPiecesStep({ href }: TutorialStepProps) {
       <div className="flex flex-col gap-fl-2 text-text-2">
         <h1 className="text-fl-2 leading-tight text-text-1">How it works</h1>
         <p>
-          Meet the puck <IconPuck /> and the blocker{" "}
-          <IconBlocker />. You move both by clicking them, then choosing a
-          direction to push them, stopping at the first
-          wa<span className="text-ui-4">ll</span> or other piece.
+          Your goal is simple: get the puck <IconPuck /> to stop{" "}
+          <strong>exactly</strong> on the target{" "}
+          <IconDestination />, using the blockers <IconBlocker /> to help you.
         </p>
 
         <p>
-          Your goal: get the puck <IconPuck /> to stop <strong>exactly</strong>
-          {" "}
-          on the target <IconDestination />.
+          Click a blocker <IconBlocker /> or the puck <IconPuck />{" "}
+          to select it, then decide where to move it.<br />
+          The caveat: pieces <strong>keep sliding</strong>{" "}
+          until they hit something.
+        </p>
+
+        <p className="pointer-fine:hidden">
+          Tip: you can flick/swipe the pieces instead of clicking
         </p>
       </div>
 

--- a/islands/tutorial-dialog.tsx
+++ b/islands/tutorial-dialog.tsx
@@ -129,8 +129,9 @@ function TutorialPiecesStep({ href }: TutorialStepProps) {
         <h1 className="text-fl-2 leading-tight text-text-1">How it works</h1>
         <p>
           Meet the puck <IconPuck /> and the blocker{" "}
-          <IconBlocker />. They both slide until they hit each other or a
-          wa<span className="text-ui-4">ll</span>.
+          <IconBlocker />. You move both by clicking them, then choosing a
+          direction to push them, stopping at the first
+          wa<span className="text-ui-4">ll</span> or other piece.
         </p>
 
         <p>

--- a/islands/tutorial-dialog.tsx
+++ b/islands/tutorial-dialog.tsx
@@ -135,8 +135,8 @@ function TutorialPiecesStep({ href }: TutorialStepProps) {
 
         <p>
           Click a blocker <IconBlocker /> or the puck <IconPuck />{" "}
-          to select it, then decide where to move it.<br />
-          The caveat: pieces <strong>keep sliding</strong>{" "}
+          to select it, then decide which direction to move it.<br />
+          The catch: pieces <strong>keep sliding</strong>{" "}
           until they hit something.
         </p>
 

--- a/routes/puzzles/[slug]/index.tsx
+++ b/routes/puzzles/[slug]/index.tsx
@@ -26,6 +26,7 @@ import { ControlsPanel } from "#/islands/controls-panel.tsx";
 import { DifficultyBadge } from "#/islands/difficulty-badge.tsx";
 import { HintDialog } from "#/islands/hint-dialog.tsx";
 import { SolutionDialog } from "#/islands/solution-dialog.tsx";
+import { SolveDialog } from "#/islands/solve-dialog.tsx";
 import { isDev } from "#/lib/env.ts";
 import { withSpan } from "#/lib/tracing.ts";
 import { trackPuzzleSolved, trackSkillLevelUp } from "#/lib/tracking.ts";
@@ -172,13 +173,19 @@ export default define.page<typeof handler>(function PuzzleDetails(props) {
         </div>
 
         <div className="relative">
-          <Board href={href} puzzle={puzzle} mode={mode} />
+          <Board
+            href={href}
+            puzzle={puzzle}
+            mode={mode}
+            isNew={props.state.user.skillLevel === null}
+          />
 
           {props.state.user.skillLevel === null && (
             <TutorialNudge
               className={clsx(
                 "max-lg:max-w-2xs max-lg:place-self-center max-lg:mt-fl-2",
                 "lg:absolute lg:ml-fl-3 lg:left-full lg:top-1/2 lg:-translate-y-1/2",
+                "print:hidden",
               )}
             />
           )}
@@ -208,6 +215,7 @@ export default define.page<typeof handler>(function PuzzleDetails(props) {
       </a>
 
       <HintDialog puzzle={puzzle} href={href} />
+      <SolveDialog puzzle={puzzle} href={href} />
 
       <SolutionDialog
         href={href}

--- a/routes/puzzles/tutorial/index.tsx
+++ b/routes/puzzles/tutorial/index.tsx
@@ -169,6 +169,7 @@ export default define.page<typeof handler>(function PuzzleTutorial(props) {
             href={href}
             puzzle={puzzle}
             mode={mode}
+            isNew
           />
 
           {urlMode === "solve" && (

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,33 @@
+# Intro animations for puck and bouncers
+
+## Problem
+
+Users don't realise bouncers can be moved — they look like fixed obstacles. Even with onboarding tips, the affordance is missing in the actual game board.
+
+## Solution
+
+Play idle animations on first visit to draw attention to interactive pieces:
+- **Puck** — pulse (scale breathe), signals "this is the main piece"
+- **Bouncers** — jiggle (z-axis rotation, iOS-style), signals "I can be pushed"
+
+Animations only show for new users (`skillLevel === null`) and are dismissed per piece type on first click.
+
+## Behaviour
+
+- Animations play on puzzle load when user is new (`skillLevel === null`)
+- Both loop indefinitely until dismissed
+- Clicking a puck dismisses the puck pulse; clicking a bouncer dismisses the bouncer jiggle
+- Dismissal is tracked in component state — resets on page reload (no persistence needed)
+
+## Animations
+
+Both use Open Props keyframes, no custom keyframes needed:
+
+- `pulse-puck` — `var(--animation-pulse)`, already infinite
+- `jiggle` — `var(--animation-shake-z)` + `animation-iteration-count: infinite`
+
+## Files changed
+
+- `styles.css` — add `@utility pulse-puck` and `@utility jiggle`
+- `islands/board.tsx` — add `isNew` prop; `wiggle` state object `{ puck, bouncer }`; apply animation classes; dismiss on `onFocus`
+- `routes/puzzles/[slug]/index.tsx` — pass `isNew={user.skillLevel === null}` to Board

--- a/spec.md
+++ b/spec.md
@@ -31,3 +31,4 @@ Both use Open Props keyframes, no custom keyframes needed:
 - `styles.css` — add `@utility pulse-puck` and `@utility jiggle`
 - `islands/board.tsx` — add `isNew` prop; `wiggle` state object `{ puck, bouncer }`; apply animation classes; dismiss on `onFocus`
 - `routes/puzzles/[slug]/index.tsx` — pass `isNew={user.skillLevel === null}` to Board
+- `routes/puzzles/tutorial/index.tsx` — pass `isNew` (always true in tutorial context)

--- a/styles.css
+++ b/styles.css
@@ -849,6 +849,16 @@
   Newly available custom properties definition syntax,
   which allows us to transition values without javascript.
 */
+@utility pulse-puck {
+  animation: var(--animation-pulse);
+}
+
+@utility jiggle {
+  animation: var(--animation-shake-z);
+  animation-iteration-count: infinite;
+  transform-origin: center;
+}
+
 @property --x {
   syntax: "<number>";
   inherits: true;


### PR DESCRIPTION
<!-- spec:start -->
# Intro animations for puck and bouncers

## Problem

Users don't realise bouncers can be moved — they look like fixed obstacles. Even with onboarding tips, the affordance is missing in the actual game board.

## Solution

Play idle animations on first visit to draw attention to interactive pieces:
- **Puck** — pulse (scale breathe), signals "this is the main piece"
- **Bouncers** — jiggle (z-axis rotation, iOS-style), signals "I can be pushed"

Animations only show for new users (`skillLevel === null`) and are dismissed per piece type on first click.

## Behaviour

- Animations play on puzzle load when user is new (`skillLevel === null`)
- Both loop indefinitely until dismissed
- Clicking a puck dismisses the puck pulse; clicking a bouncer dismisses the bouncer jiggle
- Dismissal is tracked in component state — resets on page reload (no persistence needed)

## Animations

Both use Open Props keyframes, no custom keyframes needed:

- `pulse-puck` — `var(--animation-pulse)`, already infinite
- `jiggle` — `var(--animation-shake-z)` + `animation-iteration-count: infinite`

## Files changed

- `styles.css` — add `@utility pulse-puck` and `@utility jiggle`
- `islands/board.tsx` — add `isNew` prop; `wiggle` state object `{ puck, bouncer }`; apply animation classes; dismiss on `onFocus`
- `routes/puzzles/[slug]/index.tsx` — pass `isNew={user.skillLevel === null}` to Board
- `routes/puzzles/tutorial/index.tsx` — pass `isNew` (always true in tutorial context)
<!-- spec:end -->

## Demo

<!-- screenshots / screen recording here -->

https://github.com/user-attachments/assets/85660c51-c4a5-450e-bf77-c223753363b4


https://github.com/user-attachments/assets/69b74a9a-b9bc-4eef-ab13-35e005a47ad5
