### PR TITLE
Exclude perfect puzzles from home random

### DIFF
--- a/game/loader.ts
+++ b/game/loader.ts
@@ -162,7 +162,9 @@ type GetRandomPuzzleOptions = {
 /**
  * Gets a random puzzle from the pool matching the given difficulty options.
  */
-export async function getRandomPuzzle(options: GetRandomPuzzleOptions) {
+export async function getRandomPuzzle(
+  options: GetRandomPuzzleOptions,
+): Promise<Puzzle | null> {
   let entries = await getAvailableEntries();
 
   entries = entries
@@ -171,7 +173,7 @@ export async function getRandomPuzzle(options: GetRandomPuzzleOptions) {
     )
     .filter((puzzle) => !options.excludeSlugs?.includes(puzzle.slug));
 
-  if (!entries.length) throw new Error("Unable to get random puzzle");
+  if (!entries.length) return null;
 
   const entry = entries[Math.floor(Math.random() * entries.length)];
 

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -17,6 +17,7 @@ import { define } from "#/core.ts";
 import { getBestMoves, listUserSolutions } from "#/db/solutions.ts";
 import { getUserStats } from "#/db/stats.ts";
 import {
+  getAvailableEntries,
   getLatestPuzzle,
   getOnboardingPuzzle,
   getRandomPuzzle,
@@ -61,28 +62,22 @@ export const handler = define.handlers<PageData>({
       })
       : null;
 
+    const bestMoves = getBestMoves(solutions);
+    const entries = await getAvailableEntries();
+    const optimalSlugs = entries
+      .filter((entry) => bestMoves[entry.slug] === entry.minMoves)
+      .map((entry) => entry.slug);
+
     const randomPuzzle = user.skillLevel !== null && !onboardingPuzzle
       ? await getRandomPuzzle({
-        excludeSlugs: [dailyPuzzle.slug],
+        excludeSlugs: [dailyPuzzle.slug, ...optimalSlugs],
         difficulty: user.skillLevel === "expert"
           ? ["easy", "medium", "hard"]
           : ["easy", "medium"],
       })
       : null;
 
-    // User must get either onboardingPuzzle or randomPuzzle
-    if (user.skillLevel && !onboardingPuzzle && !randomPuzzle) {
-      throw new HttpError(500, "Unable to get random puzzle");
-    }
-
     const userStats = await getUserStats(ctx.state.userId, solutions);
-
-    const bestMoves = getBestMoves(
-      solutions.filter((solution) =>
-        solution.puzzleSlug === dailyPuzzle.slug ||
-        solution.puzzleSlug === randomPuzzle?.slug
-      ),
-    );
 
     return page({
       dailyPuzzle,

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,41 @@
+# Exclude optimally solved puzzles from random
+
+## Problem
+
+The home page random puzzle can land on a puzzle the user has already solved
+at minimum moves. There's nothing left to achieve — no better move count to
+chase. This wastes the one random slot.
+
+## Solution
+
+Exclude puzzles where the user's best solve equals `minMoves` from the random
+puzzle pool. Already-solved-but-not-optimal puzzles stay eligible — there's
+still a reason to revisit them.
+
+### Changes to `routes/index.tsx`
+
+1. Compute `getBestMoves(solutions)` for all user solutions (currently filtered
+   to daily+random only — widen to all)
+2. Build optimal slug set by comparing against `entry.minMoves` from
+   `getAvailableEntries()` (cached, free)
+3. Pass optimal slugs to `getRandomPuzzle` via `excludeSlugs`
+
+```
+const allBestMoves = getBestMoves(solutions);
+const entries = await getAvailableEntries();
+const optimalSlugs = entries
+  .filter(e => allBestMoves[e.slug] === e.minMoves)
+  .map(e => e.slug);
+```
+
+### `getRandomPuzzle` — return `null` on empty pool
+
+Currently throws when no entries match. Change to return `null` so the caller
+can handle the empty case. This is needed by both this PR and the endgame PR.
+
+### What this does NOT do
+
+- No new KV reads — `solutions` is already fetched
+- No UI changes — the random puzzle card looks the same
+- No changes to `getBestMoves`
+- Doesn't affect the daily puzzle or onboarding puzzle slots


### PR DESCRIPTION
<!-- spec:start -->
# Exclude optimally solved puzzles from random

## Problem

The home page random puzzle can land on a puzzle the user has already solved
at minimum moves. There's nothing left to achieve — no better move count to
chase. This wastes the one random slot.

## Solution

Exclude puzzles where the user's best solve equals `minMoves` from the random
puzzle pool. Already-solved-but-not-optimal puzzles stay eligible — there's
still a reason to revisit them.

### Changes to `routes/index.tsx`

1. Compute `getBestMoves(solutions)` for all user solutions (currently filtered
   to daily+random only — widen to all)
2. Build optimal slug set by comparing against `entry.minMoves` from
   `getAvailableEntries()` (cached, free)
3. Pass optimal slugs to `getRandomPuzzle` via `excludeSlugs`

```
const allBestMoves = getBestMoves(solutions);
const entries = await getAvailableEntries();
const optimalSlugs = entries
  .filter(e => allBestMoves[e.slug] === e.minMoves)
  .map(e => e.slug);
```

### `getRandomPuzzle` — return `null` on empty pool

Currently throws when no entries match. Change to return `null` so the caller
can handle the empty case. This is needed by both this PR and the endgame PR.

### What this does NOT do

- No new KV reads — `solutions` is already fetched
- No UI changes — the random puzzle card looks the same
- No changes to `getBestMoves`
- Doesn't affect the daily puzzle or onboarding puzzle slots
<!-- spec:end -->

## Demo

https://github.com/user-attachments/assets/672df6f1-deea-4642-8591-e6e159e9aa1f


<!-- screenshots / screen recording here -->
