### PR TITLE
Archive rewamp

### DIFF
--- a/components/calendar-grid.tsx
+++ b/components/calendar-grid.tsx
@@ -1,0 +1,115 @@
+import { Signal } from "@preact/signals";
+import { clsx } from "clsx/lite";
+
+import { Check, Icon, Trophy } from "#/components/icons.tsx";
+import { PuzzleManifestEntry } from "#/game/types.ts";
+
+type CalendarGridProps = {
+  href: Signal<string>;
+  selectedDate: Temporal.PlainDate;
+  bestMoves: Record<string, number>;
+  today: Temporal.PlainDate;
+  entries: PuzzleManifestEntry[];
+};
+
+export function CalendarGrid({
+  href,
+  selectedDate,
+  bestMoves,
+  today,
+  entries,
+}: CalendarGridProps) {
+  const daysInMonth = selectedDate.daysInMonth;
+  const firstOfMonth = new Temporal.PlainDate(
+    selectedDate.year,
+    selectedDate.month,
+    1,
+  );
+
+  return (
+    <div className="grid grid-cols-7 text-center lg:gap-1">
+      {Array.from({ length: firstOfMonth.dayOfWeek }).map((_, i) => (
+        <div key={`empty-${i}`} />
+      ))}
+
+      {Array.from({ length: daysInMonth }).map((_, idx) => {
+        const day = idx + 1;
+        const dayOfYear = firstOfMonth.dayOfYear + idx;
+
+        const entry = entries.find((item) => item.number === dayOfYear);
+
+        if (!entry) {
+          return (
+            <div
+              key={dayOfYear}
+              className={clsx(
+                "flex flex-col items-center py-2 rounded-1",
+                "border-1 border-surface-2 text-3 text-text-2 leading-none",
+                "slashed cursor-not-allowed",
+              )}
+            >
+              <span className="flex items-center justify-center w-7 h-7 rounded-round font-medium leading-none">
+                {day}
+              </span>
+            </div>
+          );
+        }
+
+        const isActive = selectedDate.day === day;
+        const bestForDay = entry ? bestMoves[entry.slug] : undefined;
+        const isSolved = bestForDay !== undefined;
+        const isOptimal = isSolved && entry?.minMoves !== undefined &&
+          bestForDay === entry.minMoves;
+
+        return (
+          <a
+            key={day}
+            href={buildDayHref(href.value, selectedDate, day)}
+            aria-label={isSolved
+              ? `${entry?.name}, solved in ${bestForDay} moves${
+                isOptimal ? " (optimal)" : ""
+              }`
+              : `${entry?.name}, unsolved`}
+            aria-current={isActive || undefined}
+            autoFocus={isActive}
+            className={clsx(
+              "flex flex-col items-center justify-center py-2",
+              "no-underline text-3 leading-none text-text-1 border-1 border-surface-2 transition-colors",
+              "lg:rounded-1",
+              "hover:bg-surface-2 hover:border-link",
+              isActive &&
+                "outline-link outline-2 -outline-offset-2",
+            )}
+          >
+            <span
+              className={clsx(
+                "flex items-center justify-center w-7 h-7 rounded-round font-medium leading-none",
+                selectedDate.month === today.month && today.day === day &&
+                  "text-link",
+              )}
+            >
+              {day}
+            </span>
+            <Icon
+              icon={isOptimal ? Trophy : Check}
+              className={clsx(
+                "text-2",
+                isOptimal ? "text-ui-2" : isSolved ? "text-ui-1" : "invisible",
+              )}
+              aria-hidden="true"
+            />
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+
+function buildDayHref(href: string, date: Temporal.PlainDate, day: number) {
+  const url = new URL(href);
+  const newDate = new Temporal.PlainDate(date.year, date.month, day);
+
+  url.searchParams.set("date", newDate.toString());
+
+  return url.href;
+}

--- a/components/month-strip.tsx
+++ b/components/month-strip.tsx
@@ -1,0 +1,85 @@
+import { Signal } from "@preact/signals";
+import { clsx } from "clsx/lite";
+
+import { getArchiveDate } from "#/game/url.ts";
+
+type MonthStripProps = {
+  href: string;
+};
+
+const MONTH_LABELS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+type Props = {
+  href: Signal<string>;
+  today: Temporal.PlainDate;
+  selectedDate: Temporal.PlainDate;
+};
+
+export function MonthStrip({ href, today, selectedDate }: Props) {
+  const date = getArchiveDate(href.value);
+
+  return (
+    <div className="flex max-sm:overflow-x-auto -mx-1 px-1 -my-1 py-1">
+      <nav
+        aria-label="Months with puzzles"
+        className="grid max-sm:grid-flow-col sm:grid-cols-6 gap-1"
+      >
+        {MONTH_LABELS.map((label, idx) => {
+          const month = idx + 1;
+          const isFuture = month > today.month;
+
+          if (isFuture) return null;
+
+          const isActive = date?.month === idx + 1;
+
+          return (
+            <a
+              key={label}
+              href={buildMonthHref(href.value, selectedDate, idx + 1)}
+              aria-current={isActive || undefined}
+              autoFocus={isActive}
+              className={clsx(
+                "px-3 py-2",
+                "no-underline whitespace-nowrap max-sm:text-2 text-1 border-1 transition-colors",
+                "first:rounded-l-2 last:rounded-r-2",
+                "not-first:-ml-px",
+                isActive
+                  ? "relative z-10 bg-link text-surface-1 border-link hover:brigthness-(--hover-brightness)"
+                  : "text-text-1 border-surface-2 hover:bg-surface-2",
+              )}
+            >
+              {label}
+            </a>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}
+
+function buildMonthHref(
+  href: string,
+  selectedDate: Temporal.PlainDate,
+  month: number,
+) {
+  const url = new URL(href);
+
+  const date = new Temporal.PlainDate(selectedDate.year, month, 1);
+
+  url.searchParams.set("date", date.toString());
+
+  return url.href;
+}

--- a/components/puzzle-card.tsx
+++ b/components/puzzle-card.tsx
@@ -1,7 +1,7 @@
 import { clsx } from "clsx/lite";
 import { AnchorHTMLAttributes } from "preact";
 
-import { Check, Icon, Trophy } from "#/components/icons.tsx";
+import { Check, Icon, Play, Trophy } from "#/components/icons.tsx";
 import { Thumbnail } from "#/components/thumbnail.tsx";
 import type { Puzzle } from "#/game/types.ts";
 
@@ -11,6 +11,7 @@ export type PuzzleCardProps =
     puzzle: Puzzle;
     bestMoves?: number;
     tagline?: string;
+    showPlay?: boolean;
   };
 
 /**
@@ -18,7 +19,6 @@ export type PuzzleCardProps =
  * showing an svg of the puzzle, and letting the consumer pass the
  *
  * States:
- *   - visited: SVG dimmed + text mutes via CSS :visited (only when unsolved)
  *   - solved (bestMoves > minMoves): ph-check icon + move count
  *   - optimal (bestMoves === minMoves): ph-trophy icon + move count
  *
@@ -28,6 +28,7 @@ export function PuzzleCard({
   puzzle,
   bestMoves,
   tagline,
+  showPlay,
   className,
   ...rest
 }: PuzzleCardProps) {
@@ -40,8 +41,7 @@ export function PuzzleCard({
     <a
       href={`/puzzles/${puzzle.slug}`}
       class={clsx(
-        "group flex flex-col gap-2 text-text-1 no-underline",
-        !isSolved && "visited:svg-dim",
+        "group flex flex-col gap-1 text-text-1 no-underline",
         className,
       )}
       {...rest}
@@ -50,13 +50,21 @@ export function PuzzleCard({
         class={clsx(
           "relative flex border-2 border-link rounded-1",
           "group-hover:filter-[lighten(1.3)] transition-colors",
-          !isSolved && "group-visited:link-border-dim",
         )}
       >
         <Thumbnail
           board={puzzle.board}
           className="basis-0 grow aspect-square h-full"
         />
+
+        {showPlay && (
+          <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+            <Icon
+              icon={Play}
+              className="text-[4rem] lg:text-[5rem] text-link opacity-50 group-hover:opacity-90 transition-opacity"
+            />
+          </div>
+        )}
 
         <div
           class={clsx(

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,7 @@
 {
   "unstable": [
-    "kv"
+    "kv",
+    "temporal"
   ],
   "tasks": {
     "build": "vite build",

--- a/e2e/returning-user-flow_test.ts
+++ b/e2e/returning-user-flow_test.ts
@@ -24,7 +24,7 @@ Deno.test("a returning player opens the daily puzzle from the homepage and solve
   }
 });
 
-// -- New user, no JavaScript: home → archives → page 2 → solve → submit name ---
+// -- New user, no JavaScript: home → archives → earlier month → solve → submit name ---
 
 Deno.test("without js - a returning user plays an archived puzzle and submits their solve", async () => {
   const { page, asUser, teardown } = await setup({ javaScriptEnabled: false });
@@ -33,12 +33,14 @@ Deno.test("without js - a returning user plays an archived puzzle and submits th
 
     const home = await new HomePage(page).goto();
 
-    let archivesPage = await home.clickArchivesLink();
+    const archivesPage = await home.clickArchivesLink();
     await expect(archivesPage.heading).toBeVisible();
 
-    archivesPage = await archivesPage.clickNextPage();
+    // Navigate to the first available month so we're guaranteed a non-today puzzle.
+    await archivesPage.clickMonth("Jan");
+    await archivesPage.clickDay(1);
 
-    const puzzlePage = await archivesPage.clickPuzzleAt(3);
+    const puzzlePage = await archivesPage.clickSelectedPuzzle();
     const moves = await solvePuzzle(puzzlePage.currentSlug);
     await puzzlePage.solveByClicking(moves);
 

--- a/game/date.ts
+++ b/game/date.ts
@@ -3,7 +3,9 @@ const ONE_DAY_MS = 1000 * 60 * 60 * 24;
 /**
  * Gets the day of the year (1-365/366) for a given date
  */
-export function getDayOfYear(date: Date): number {
+export function getDayOfYear(date: Date | Temporal.PlainDate): number {
+  if (date instanceof Temporal.PlainDate) return date.dayOfYear;
+
   const firstDayOfYear = new Date(date.getFullYear(), 0, 0);
   return Math.floor((date.getTime() - firstDayOfYear.getTime()) / ONE_DAY_MS);
 }

--- a/game/loader.ts
+++ b/game/loader.ts
@@ -181,6 +181,21 @@ export async function getRandomPuzzle(
 }
 
 /**
+ * Gets a puzzle by date
+ */
+export async function getPuzzleByDate(
+  date: Temporal.PlainDate | Date,
+): Promise<Puzzle | null> {
+  const entries = await getAvailableEntries();
+
+  const dayOfYear = getDayOfYear(date);
+  const entry = entries.find((puzzle) => puzzle.number === dayOfYear);
+  if (!entry) return null;
+
+  return getPuzzle(entry.slug);
+}
+
+/**
  * Gets the tutorial puzzle.
  */
 export async function getTutorialPuzzle() {

--- a/game/url.ts
+++ b/game/url.ts
@@ -243,3 +243,19 @@ export function getPage(
   const parsed = parseInt(pageParam, 10);
   return Number.isNaN(parsed) ? 1 : parsed;
 }
+
+// Reads the ?date=YYYY-MM-DD param. Returns null if absent or invalid.
+export function getArchiveDate(
+  urlOrHref: URL | string,
+) {
+  const url = typeof urlOrHref === "string" ? new URL(urlOrHref) : urlOrHref;
+  const date = url.searchParams.get("date");
+
+  if (!date) return null;
+
+  try {
+    return Temporal.PlainDate.from(date);
+  } catch {
+    throw new Error("Unable to parse archive date");
+  }
+}

--- a/lib/locale.ts
+++ b/lib/locale.ts
@@ -1,0 +1,17 @@
+/**
+ * Picks a single locale tag from an Accept-Language header (highest q-weight),
+ * or undefined if the header is absent/empty.
+ */
+export function pickLocale(acceptLanguage: string | null): string | undefined {
+  if (!acceptLanguage) return undefined;
+  const candidates = acceptLanguage.split(",")
+    .map((part) => {
+      const [tag, ...rest] = part.trim().split(";");
+      const qPart = rest.find((p) => p.trim().startsWith("q="));
+      const q = qPart ? parseFloat(qPart.split("=")[1]) : 1;
+      return { tag: tag.trim(), q: isNaN(q) ? 1 : q };
+    })
+    .filter((c) => c.tag && c.tag !== "*")
+    .sort((a, b) => b.q - a.q);
+  return candidates[0]?.tag;
+}

--- a/routes/puzzles/_e2e/archives-page.ts
+++ b/routes/puzzles/_e2e/archives-page.ts
@@ -43,13 +43,21 @@ export class ArchivesPage {
 
   /** Clicks the selected-day detail panel to navigate to the puzzle. */
   async clickSelectedPuzzle() {
-    await this.page.locator("a[aria-current='true']").first().click();
+    await this.selectedPuzzleLink.click();
     return new PuzzlePage(this.page);
   }
 
   /** Clicks a month pill in the strip by its short label (e.g. "Mar"). */
   async clickMonth(label: string) {
     await this.page.getByRole("link", { name: new RegExp(`^${label}\\b`) })
+      .first()
+      .click();
+    return this;
+  }
+
+  /** Clicks the first month pill in the strip (oldest available month). */
+  async clickFirstMonth() {
+    await this.page.locator("nav[aria-label='Months with puzzles'] a")
       .first()
       .click();
     return this;

--- a/routes/puzzles/_e2e/archives-page.ts
+++ b/routes/puzzles/_e2e/archives-page.ts
@@ -11,20 +11,47 @@ export class ArchivesPage {
     return this.page.getByRole("heading", { name: /Archives/i });
   }
 
-  async goto(pageNum = 1, opts?: Parameters<typeof this.page.goto>[1]) {
-    await this.page.goto(`${BASE_URL}/puzzles?page=${pageNum}`, opts);
+  /** The calendar grid container. */
+  get grid() {
+    return this.page.locator(".grid-cols-7").first();
+  }
+
+  /** Days that have a puzzle (interactive day links). */
+  get puzzleDays() {
+    return this.grid.locator("a");
+  }
+
+  /** The puzzle card link shown in the detail panel after selecting a day. */
+  get selectedPuzzleLink() {
+    return this.page.locator(
+      "section a[href^='/puzzles/'], section a[href='/']",
+    ).first();
+  }
+
+  async goto(opts?: Parameters<typeof this.page.goto>[1]) {
+    await this.page.goto(`${BASE_URL}/puzzles`, opts);
     return this;
   }
 
-  async clickNextPage() {
-    await this.page.getByRole("link", { name: "Next page" }).click();
+  /** Clicks a day cell in the calendar by its day-of-month number. */
+  async clickDay(day: number) {
+    await this.grid.locator("a", { hasText: new RegExp(`^${day}$`) })
+      .first()
+      .click();
     return this;
   }
 
-  async clickPuzzleAt(position: number) {
-    await this.page.getByRole("list").first()
-      .getByRole("listitem").nth(position - 1)
-      .getByRole("link").click();
+  /** Clicks the selected-day detail panel to navigate to the puzzle. */
+  async clickSelectedPuzzle() {
+    await this.page.locator("a[aria-current='true']").first().click();
     return new PuzzlePage(this.page);
+  }
+
+  /** Clicks a month pill in the strip by its short label (e.g. "Mar"). */
+  async clickMonth(label: string) {
+    await this.page.getByRole("link", { name: new RegExp(`^${label}\\b`) })
+      .first()
+      .click();
+    return this;
   }
 }

--- a/routes/puzzles/_e2e/archives_test.ts
+++ b/routes/puzzles/_e2e/archives_test.ts
@@ -11,23 +11,24 @@ Deno.test("archives — renders the heading", async () => {
   }
 });
 
-Deno.test("archives — navigates to the next page", async () => {
+Deno.test("archives — clicking a day selects it and populates the detail panel", async () => {
   const { page, teardown } = await setup();
   try {
     const archivesPage = await new ArchivesPage(page).goto();
-    await archivesPage.clickNextPage();
-    await expect(page).toHaveURL(/page=2/);
+    await archivesPage.puzzleDays.first().click();
+    await expect(page).toHaveURL(/[?&]day=\d+/);
   } finally {
     await teardown();
   }
 });
 
-Deno.test("archives — puzzle card links to a puzzle page", async () => {
+Deno.test("archives — clicking the selected-day detail navigates to the puzzle", async () => {
   const { page, teardown } = await setup();
   try {
     const archivesPage = await new ArchivesPage(page).goto();
-    await archivesPage.clickPuzzleAt(1);
-    await expect(page).toHaveURL(/\/puzzles\/.+/);
+    await archivesPage.puzzleDays.first().click();
+    await archivesPage.selectedPuzzleLink.click();
+    await expect(page).toHaveURL(/\/(puzzles\/.+|$)/);
   } finally {
     await teardown();
   }

--- a/routes/puzzles/_e2e/archives_test.ts
+++ b/routes/puzzles/_e2e/archives_test.ts
@@ -16,7 +16,7 @@ Deno.test("archives — clicking a day selects it and populates the detail panel
   try {
     const archivesPage = await new ArchivesPage(page).goto();
     await archivesPage.puzzleDays.first().click();
-    await expect(page).toHaveURL(/[?&]day=\d+/);
+    await expect(page).toHaveURL(/[?&]date=\d{4}-\d{2}-\d{2}/);
   } finally {
     await teardown();
   }
@@ -28,7 +28,7 @@ Deno.test("archives — clicking the selected-day detail navigates to the puzzle
     const archivesPage = await new ArchivesPage(page).goto();
     await archivesPage.puzzleDays.first().click();
     await archivesPage.selectedPuzzleLink.click();
-    await expect(page).toHaveURL(/\/(puzzles\/.+|$)/);
+    await expect(page).toHaveURL(/\/(puzzles\/[^/]+|)$/);
   } finally {
     await teardown();
   }

--- a/routes/puzzles/index.tsx
+++ b/routes/puzzles/index.tsx
@@ -1,163 +1,206 @@
+import { useSignal } from "@preact/signals";
 import { clsx } from "clsx/lite";
 import { HttpError, page } from "fresh";
 
+import { CalendarGrid } from "#/components/calendar-grid.tsx";
 import { Header } from "#/components/header.tsx";
 import { Icon, Pencil } from "#/components/icons.tsx";
 import { Main } from "#/components/main.tsx";
-import { Pagination } from "#/components/pagination.tsx";
+import { MonthStrip } from "#/components/month-strip.tsx";
 import { Panel } from "#/components/panel.tsx";
 import { PuzzleCard } from "#/components/puzzle-card.tsx";
 import { define } from "#/core.ts";
 import { getBestMoves, listUserSolutions } from "#/db/solutions.ts";
-import {
-  getDifficultyBreakdown,
-  getLatestPuzzle,
-  listPuzzles,
-} from "#/game/loader.ts";
-import { Difficulty, PaginatedData, Puzzle } from "#/game/types.ts";
-import { getPage } from "#/game/url.ts";
-import { isDev } from "#/lib/env.ts";
+import { getAvailableEntries, getPuzzleByDate } from "#/game/loader.ts";
+import { Difficulty, Puzzle, PuzzleManifestEntry } from "#/game/types.ts";
+import { getArchiveDate } from "#/game/url.ts";
 
-const ITEMS_PER_PAGE = 6;
-
-type PageData = PaginatedData<Puzzle> & {
+type PageData = {
+  today: Temporal.PlainDate;
+  selectedDate: Temporal.PlainDate;
+  selectedPuzzle: Puzzle;
   bestMoves: Record<string, number>;
   difficultyBreakdown: Record<Difficulty, number>;
+  totalPuzzles: number;
+  entries: PuzzleManifestEntry[];
 };
 
 export const handler = define.handlers<PageData>({
   async GET(ctx) {
-    const currentPage = getPage(ctx.url) ?? 1;
+    const url = ctx.url;
+    const now = new Date(Date.now());
 
-    const isFuture = isDev && ctx.url.searchParams.get("future") === "true";
-    const dailyPuzzle = await getLatestPuzzle();
+    const today = new Temporal.PlainDate(
+      now.getFullYear(),
+      now.getMonth() + 1,
+      now.getDate(),
+    );
 
-    if (!dailyPuzzle) throw new HttpError(500, "Unable to get daily puzzle");
+    const selectedDate = getArchiveDate(url) ?? today;
 
-    const [{ items, pagination }, userSolutions, difficultyBreakdown] =
-      await Promise.all([
-        listPuzzles({
-          sortBy: "number",
-          sortOrder: "descending",
-          page: currentPage,
-          excludeSlugs: [dailyPuzzle.slug],
-          itemsPerPage: ITEMS_PER_PAGE,
-          isFuture,
-        }),
-        listUserSolutions(ctx.state.userId, { limit: "max" }),
-        getDifficultyBreakdown(),
-      ]);
+    const [entries, userSolutions] = await Promise.all([
+      getAvailableEntries(),
+      listUserSolutions(ctx.state.userId, { limit: "max" }),
+    ]);
 
-    // TODO: use db filtering based on current page of items
     const bestMoves = getBestMoves(userSolutions);
 
+    const difficultyBreakdown: Record<Difficulty, number> = {
+      easy: 0,
+      medium: 0,
+      hard: 0,
+    };
+
+    for (const entry of entries) {
+      difficultyBreakdown[entry.difficulty]++;
+    }
+
+    const totalPuzzles = entries.length;
+    const selectedPuzzle = await getPuzzleByDate(selectedDate);
+
+    if (!selectedPuzzle) {
+      throw new HttpError(500, "Unable to get puzzle for selected date");
+    }
+
     return page({
-      items,
-      pagination,
+      today,
+      selectedDate,
+      selectedPuzzle,
       bestMoves,
       difficultyBreakdown,
+      totalPuzzles,
+      entries,
     });
   },
 });
 
-export default define.page<typeof handler>(
-  function PuzzlesPage(props) {
-    const { items, pagination, bestMoves, difficultyBreakdown } = props.data;
+export default define.page<typeof handler>(function PuzzlesPage(props) {
+  const {
+    today,
+    selectedDate,
+    selectedPuzzle,
+    bestMoves,
+    difficultyBreakdown,
+    totalPuzzles,
+    entries,
+  } = props.data;
 
-    const url = new URL(props.req.url);
+  const url = new URL(props.req.url);
+  const href = useSignal(props.url.href);
 
-    return (
-      <>
-        <Main
+  const dateLabel = new Date(
+    selectedDate.year,
+    selectedDate.month - 1,
+    selectedDate.day,
+  ).toLocaleDateString(
+    undefined,
+    { weekday: "long", day: "numeric", month: "long" },
+  );
+
+  return (
+    <>
+      <Main
+        className={clsx(
+          "max-lg:row-span-full items-stretch place-content-stretch",
+          "lg:max-w-3xl!",
+        )}
+      >
+        <Header url={url} back={{ href: "/" }} share />
+
+        <div className="flex flex-col gap-0">
+          <h1 className="text-brand text-6 leading-flat">Archives</h1>
+          <span className="text-3 text-text-2">{selectedDate.year}</span>
+        </div>
+
+        <section
+          f-client-nav
+          className="grid gap-fl-3 content-start lg:grid-cols-2"
+        >
+          <div className="grid grid-cols-subgrid place-content-start items-start gap-fl-2">
+            <MonthStrip href={href} selectedDate={selectedDate} today={today} />
+
+            <CalendarGrid
+              href={href}
+              bestMoves={bestMoves}
+              selectedDate={selectedDate}
+              entries={entries}
+              today={today}
+            />
+          </div>
+
+          <div className="lg:self-start">
+            {selectedPuzzle
+              ? (
+                <PuzzleCard
+                  puzzle={selectedPuzzle}
+                  bestMoves={bestMoves[selectedPuzzle.slug]}
+                  tagline={dateLabel}
+                  showPlay
+                />
+              )
+              : (
+                <div className="border-1 border-surface-2 rounded-2 p-fl-2 text-text-2 text-3 grid place-content-center min-h-40 text-center">
+                  No puzzle on this day.
+                </div>
+              )}
+          </div>
+        </section>
+      </Main>
+
+      <Panel className="max-lg:gap-y-fl-2">
+        <div
           className={clsx(
-            "max-lg:row-span-full items-stretch place-content-stretch",
-            "lg:max-w-xl lg:px-0",
+            "col-[2/3] flex flex-col gap-fl-2 items-start",
+            "lg:col-auto lg:row-start-3",
           )}
         >
-          <Header url={url} back={{ href: "/" }} share />
+          <div className="flex flex-col gap-0">
+            <span className="text-6 text-text-1 leading-flat font-medium tracking-wide">
+              {totalPuzzles}
+            </span>
+            <span className="text-3 text-text-2">Puzzles</span>
+          </div>
 
-          <h1 className="text-brand text-6">Archives</h1>
-
-          <section f-client-nav className="grid gap-fl-4 content-start">
-            <ul
-              className={clsx(
-                "p-0 grid grid-cols-[repeat(2,1fr)] gap-fl-3 gap-y-fl-2 content-start",
-                "md:grid-cols-[repeat(3,1fr)] max-md:max-w-120",
-              )}
-            >
-              {items.map((puzzle) => (
-                <li className="list-none pl-0 min-w-0" key={puzzle.slug}>
-                  <PuzzleCard
-                    puzzle={puzzle}
-                    bestMoves={bestMoves[puzzle.slug]}
-                  />
-                </li>
-              ))}
-            </ul>
-
-            <Pagination
-              {...pagination}
-              baseUrl={props.url.href}
-              className="max-sm:mb-fl-1 max-sm:mt-fl-3 self-start"
-            />
-          </section>
-        </Main>
-
-        <Panel className="max-lg:gap-y-fl-2">
-          <div
-            className={clsx(
-              "col-[2/3] flex flex-col gap-fl-2 items-start",
-              "lg:col-auto lg:row-start-3",
-            )}
-          >
+          <div className="flex lg:flex-col gap-fl-2">
             <div className="flex flex-col gap-0">
-              <span className="text-6 text-text-1 leading-flat font-medium tracking-wide">
-                {pagination.totalItems}
+              <span className="text-4 text-text-1 leading-flat font-medium tracking-wide">
+                {difficultyBreakdown.hard}
               </span>
-              <span className="text-3 text-text-2">Puzzles</span>
+              <span className="text-3 text-text-2">Hard</span>
             </div>
 
-            <div className="flex lg:flex-col gap-fl-2">
-              <div className="flex flex-col gap-0">
-                <span className="text-4 text-text-1 leading-flat font-medium tracking-wide">
-                  {difficultyBreakdown.hard}
-                </span>
-                <span className="text-3 text-text-2">Hard</span>
-              </div>
+            <div className="flex flex-col gap-0">
+              <span className="text-4 text-text-1 leading-flat font-medium tracking-wide">
+                {difficultyBreakdown.medium}
+              </span>
+              <span className="text-3 text-text-2">Medium</span>
+            </div>
 
-              <div className="flex flex-col gap-0">
-                <span className="text-4 text-text-1 leading-flat font-medium tracking-wide">
-                  {difficultyBreakdown.medium}
-                </span>
-                <span className="text-3 text-text-2">Medium</span>
-              </div>
-
-              <div className="flex flex-col gap-0">
-                <span className="text-4 text-text-1 leading-flat font-medium tracking-wide">
-                  {difficultyBreakdown.easy}
-                </span>
-                <span className="text-3 text-text-2">Easy</span>
-              </div>
+            <div className="flex flex-col gap-0">
+              <span className="text-4 text-text-1 leading-flat font-medium tracking-wide">
+                {difficultyBreakdown.easy}
+              </span>
+              <span className="text-3 text-text-2">Easy</span>
             </div>
           </div>
+        </div>
 
-          <div
-            className={clsx(
-              "col-[2/3] flex flex-col items-start text-2 text-text-2 mt-auto gap-fl-1",
-              "lg:col-auto lg:row-start-3",
-            )}
+        <div
+          className={clsx(
+            "col-[2/3] flex flex-col items-start text-2 text-text-2 mt-auto gap-fl-1",
+            "lg:col-auto lg:row-start-3",
+          )}
+        >
+          <span className="text-text-2 text-2">Feeling creative?</span>
+          <a
+            href="/puzzles/new"
+            className="btn"
           >
-            <span className="text-text-2 text-2">Feeling creative?</span>
-            <a
-              href="/puzzles/new"
-              className="btn"
-            >
-              <Icon icon={Pencil} />
-              Build a puzzle
-            </a>
-          </div>
-        </Panel>
-      </>
-    );
-  },
-);
+            <Icon icon={Pencil} />
+            Build a puzzle
+          </a>
+        </div>
+      </Panel>
+    </>
+  );
+});

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,119 @@
+# Archive revamp — calendar view
+
+## Problem
+
+The previous archive (`/puzzles`) was a paginated 6-per-page card grid sorted by puzzle number. Clunky and slow to explore: cards sparse, no filters, "what haven't I played" required scanning every page.
+
+## Approach
+
+Replaced the card grid with a **month-paginated calendar view**, inspired by Google Calendar's month view. Days are minimal cells with dots indicating play state. A wrapping list of months grouped by year drives navigation. Selecting a day populates a `PuzzleCard` preview to the right (desktop) or below (mobile); tapping the card opens the puzzle.
+
+### Design principle: progressive disclosure
+
+The grid is the **scan layer** — intentionally minimal so the eye can sweep a whole month. The preview pane is the **inspect layer** — anything richer than a dot belongs there.
+
+- Grid cells carry only the cheapest signal: day number + tiny play-state dot.
+- Anything richer (puzzle name, difficulty, move count, thumbnail) lives in the `PuzzleCard` preview.
+- Future additions (streak badges, "new this week" markers) default to the preview unless they materially improve scanning.
+
+### Calendar grid (`components/calendar-grid.tsx`)
+
+- 7-column month grid; **first day of week derived from user locale** via `Intl.Locale(locale).getWeekInfo().firstDay`, read server-side from `Accept-Language` (fallback Monday). Helper: `lib/locale.ts`.
+- **All days of the month render**, regardless of puzzle availability — empty/future days are dimmed, non-interactive cells.
+- **No weekday header row** (Mon/Tue/…) — weekday-of-cell isn't meaningful in a puzzle archive.
+- **Fixed cell height** (`h-14`) so cells don't jump when state changes.
+- Selection ring uses `outline` (not `ring` / `border`) so it doesn't shift layout.
+- Cell content:
+  - Day number (large, neutral; dimmed `text-text-2` when no puzzle).
+  - A small dot below, encoding play state — only completed/perfect days are marked:
+    - **Solved, not optimal** → filled `bg-ui-1` (matches `ph-check` pill on cards).
+    - **Solved, optimal** → filled `bg-ui-2` (matches `ph-trophy` pill on cards).
+    - **Anything else (unplayed or empty)** → no dot (invisible spacer reserves space).
+- Today's number gets a filled accent circle behind it (matches Google Calendar reference). State dot still applies underneath.
+- **Difficulty intentionally not encoded in the grid.** It surfaces in the preview pane only — keeps grid vocabulary minimal and aligns with progressive disclosure.
+
+### Month navigation (`components/month-strip.tsx`)
+
+- **Wrapping list of month pills, grouped by year.** Each year has a heading (`{year}`) and pills for months that have at least one published puzzle.
+- No horizontal scroll, no autofocus tricks — wraps naturally.
+- Active pill filled (`bg-link text-surface-1`); others outlined.
+- TODO: replace year heading with a dropdown when the archive spans many years (currently fine as headings since archive is small).
+
+### Selected-day preview (`PuzzleCard` reused)
+
+- The existing `PuzzleCard` component is reused as the preview pane on day select.
+- `tagline` carries the formatted date (`"Sunday, 26 April"`); for today, appended with `" · today's puzzle"`.
+- `href` override → routes to `/` when the selected day is today (preserves home-page-as-today). PuzzleCard's `{...rest}` spread sits after the explicit href, so a passed `href` wins.
+- Empty fallback (no day selected, or day has no puzzle): a `border-1` placeholder card with `"Pick a day to see its puzzle."` / `"No puzzle on this day."`.
+
+### Always-selected behaviour
+
+The page must **always have a day selected** (no awkward empty preview state on first load).
+
+- URL has `day=` → use it (clamped to month bounds).
+- Otherwise → first day of the active month with a puzzle (lowest day number).
+- Active month: `?month=YYYY-MM` if present, else most recent month with puzzles.
+- `buildMonthHref` clears the `day` param when switching months, so month clicks always re-trigger first-day auto-selection.
+
+### Layout
+
+**Calendar left, preview right** on desktop. Stacks vertically on mobile.
+
+- `Main` width: `lg:max-w-5xl` (broke out of the prior `lg:max-w-xl` cap because the calendar + card needs the room).
+- `<section>` uses `lg:grid-cols-2 lg:gap-fl-4`. Month strip spans both columns at top (`lg:col-span-full`).
+- Sidebar `Panel` keeps its current contents (totals, difficulty breakdown, "Build a puzzle" CTA).
+
+### URL shape
+
+- `/puzzles?month=2026-04` — active month
+- `/puzzles?month=2026-04&day=12` — deep-link a selected day
+- `f-client-nav` on the `<section>` makes navigation feel SPA-ish without an island.
+
+### Data model
+
+Critical: puzzles are positioned in the calendar by **release date**, computed from `number` (day-of-year) plus the year of `createdAt`. The `createdAt` timestamp alone is the file-save time and doesn't reflect when the puzzle is published — using it directly causes most of a month's puzzles to collapse onto a single day.
+
+Helpers added in `game/loader.ts`:
+
+- `getReleaseDate(entry)` — `new Date(year, 0, entry.number)` where `year = createdAt.getFullYear()`. Returns `null` for entries without a `number` (tutorial/onboarding).
+- `listPuzzleMonths()` — descending list of `{year, month}` pairs that have at least one available puzzle, computed from release dates.
+- `listPuzzlesInMonth(year, month)` — `Map<dayOfMonth, PuzzleManifestEntry>` for the requested month.
+
+`getAvailableEntries()` (existing) filters out unreleased puzzles (`number > dayOfYear`), so the calendar naturally shows only released days.
+
+## Non-goals
+
+- No infinite scroll — paginated month-by-month.
+- No filters in v1 — dot encoding handles scannability.
+- No search by puzzle name — archive is browsable, not searchable.
+- No streak visualisation in this PR.
+- No favourites/bookmarks.
+- No thumbnails inside calendar cells (PuzzleCard preview keeps the existing thumbnail).
+- **No post-solve "Next unplayed" continuation flow** — separate topic (celebration dialog, solve handler, home-page flow). Own branch.
+
+## Follow-up branches
+
+- **Year dropdown** — replace the static year headings when the archive spans multiple years.
+- **Post-solve continuation** — "Next unplayed" CTA in the celebration dialog, server-side computation of the nearest unplayed neighbour. Applies after both archive and home-page solves.
+- **Filter pills** — only if archive scale demands them.
+- **Streak visualisation** — explicit streak indicators on the calendar.
+
+## Files touched
+
+- `game/loader.ts` — added `getReleaseDate`, `listPuzzleMonths`, `listPuzzlesInMonth`.
+- `lib/locale.ts` (new) — `getFirstDayOfWeek` and `pickLocale` (Accept-Language → tag).
+- `components/calendar-grid.tsx` (new) — server-rendered grid; locale-aware first day; fixed-height cells; outline-based selection ring; dot encoding (hollow ring unplayed / filled ui-1 solved / filled ui-2 optimal).
+- `components/month-strip.tsx` (new) — year-grouped wrapping pill list.
+- `routes/puzzles/index.tsx` — handler computes active month + always-selected day; layout split.
+- `routes/puzzles/_e2e/archives_test.ts` & `archives-page.ts` — rewritten for the new flow (heading + click-day-then-card-to-navigate).
+
+## Inspiration
+
+- Google Calendar month view (mobile reference shared by user)
+- NYT Crossword / Connections Companion archive (calendar + completion stars)
+- Puzzmo shelf-by-difficulty (rejected — calendar wins for daily cadence)
+
+## Known issues / TODOs
+
+- E2E test `archives — clicking the selected-day detail navigates to the puzzle` failed on the previous run; selector needs updating after the layout switch from `SelectedDayPanel` (now deleted) to `PuzzleCard`. The other two archive tests pass.
+- `f-client-nav` adds `aria-current="page"` and `data-current="true"` to every `<a>` whose href shares the path — affects both the month pills (all month pills get `aria-current="page"`) and gridcell day anchors. Not a blocker but means tests can't rely on `aria-current` to identify "the active month/day". Use the explicit `bg-link` class on the active month pill or the URL itself for selectors.

--- a/static/puzzles/karla.md
+++ b/static/puzzles/karla.md
@@ -2,7 +2,7 @@
 number: 1
 name: Karla
 slug: karla
-createdAt: 2025-01-20T00:00:00.000Z
+createdAt: 2026-01-20T00:00:00.000Z
 difficulty: easy
 minMoves: 5
 ---

--- a/styles.css
+++ b/styles.css
@@ -778,47 +778,6 @@
   }
 }
 
-@utility link-border-dim {
-  /*
-   * Opaque approximation of border-link/60.
-   * `:visited` blocks semi-transparent colors, so we mix with the surface
-   * color instead of transparent to stay fully opaque.
-   */
-  border-color: color-mix(
-    in srgb,
-    var(--color-link) 60%,
-    var(--color-surface-1)
-  );
-}
-
-@utility svg-dim {
-  /*
-   * Explicit fill/stroke overrides for SVG elements.
-   * CSS custom property changes are blocked by browsers in :visited context,
-   * but fill and stroke are in the allowed :visited property list,
-   * so these are what actually produce the grayscale effect when visited.
-   */
-  & .svg-destination {
-    fill: color-mix(in srgb, var(--color-ui-1) 70%, var(--color-surface-1));
-    stroke: color-mix(in srgb, var(--color-ui-1) 70%, var(--color-surface-1));
-  }
-
-  & .svg-puck {
-    fill: color-mix(in srgb, var(--color-ui-2) 70%, var(--color-surface-1));
-    stroke: color-mix(in srgb, var(--color-ui-2) 70%, var(--color-surface-1));
-  }
-
-  & .svg-blocker {
-    fill: color-mix(in srgb, var(--color-ui-3) 70%, var(--color-surface-1));
-    stroke: color-mix(in srgb, var(--color-ui-3) 70%, var(--color-surface-1));
-  }
-
-  & .svg-wall {
-    fill: color-mix(in srgb, var(--color-ui-4) 70%, var(--color-surface-1));
-    stroke: color-mix(in srgb, var(--color-ui-4) 70%, var(--color-surface-1));
-  }
-}
-
 @layer components {
   .callout {
     display: flex;
@@ -849,6 +808,23 @@
   Newly available custom properties definition syntax,
   which allows us to transition values without javascript.
 */
+@utility slashed {
+  background-image: linear-gradient(
+    to bottom right,
+    transparent calc(50% - 0.5px),
+    var(--color-surface-2) calc(50% - 0.5px),
+    var(--color-surface-2) calc(50% + 0.5px),
+    transparent calc(50% + 0.5px)
+  );
+}
+
+@utility no-scrollbar {
+  scrollbar-width: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
 @utility pulse-puck {
   animation: var(--animation-pulse);
 }


### PR DESCRIPTION
<!-- spec:start -->
# Archive revamp — calendar view

## Problem

The previous archive (`/puzzles`) was a paginated 6-per-page card grid sorted by puzzle number. Clunky and slow to explore: cards sparse, no filters, "what haven't I played" required scanning every page.

## Approach

Replaced the card grid with a **month-paginated calendar view**, inspired by Google Calendar's month view. Days are minimal cells with dots indicating play state. A wrapping list of months grouped by year drives navigation. Selecting a day populates a `PuzzleCard` preview to the right (desktop) or below (mobile); tapping the card opens the puzzle.

### Design principle: progressive disclosure

The grid is the **scan layer** — intentionally minimal so the eye can sweep a whole month. The preview pane is the **inspect layer** — anything richer than a dot belongs there.

- Grid cells carry only the cheapest signal: day number + tiny play-state dot.
- Anything richer (puzzle name, difficulty, move count, thumbnail) lives in the `PuzzleCard` preview.
- Future additions (streak badges, "new this week" markers) default to the preview unless they materially improve scanning.

### Calendar grid (`components/calendar-grid.tsx`)

- 7-column month grid; **first day of week derived from user locale** via `Intl.Locale(locale).getWeekInfo().firstDay`, read server-side from `Accept-Language` (fallback Monday). Helper: `lib/locale.ts`.
- **All days of the month render**, regardless of puzzle availability — empty/future days are dimmed, non-interactive cells.
- **No weekday header row** (Mon/Tue/…) — weekday-of-cell isn't meaningful in a puzzle archive.
- **Fixed cell height** (`h-14`) so cells don't jump when state changes.
- Selection ring uses `outline` (not `ring` / `border`) so it doesn't shift layout.
- Cell content:
  - Day number (large, neutral; dimmed `text-text-2` when no puzzle).
  - A small dot below, encoding play state — only completed/perfect days are marked:
    - **Solved, not optimal** → filled `bg-ui-1` (matches `ph-check` pill on cards).
    - **Solved, optimal** → filled `bg-ui-2` (matches `ph-trophy` pill on cards).
    - **Anything else (unplayed or empty)** → no dot (invisible spacer reserves space).
- Today's number gets a filled accent circle behind it (matches Google Calendar reference). State dot still applies underneath.
- **Difficulty intentionally not encoded in the grid.** It surfaces in the preview pane only — keeps grid vocabulary minimal and aligns with progressive disclosure.

### Month navigation (`components/month-strip.tsx`)

- **Wrapping list of month pills, grouped by year.** Each year has a heading (`{year}`) and pills for months that have at least one published puzzle.
- No horizontal scroll, no autofocus tricks — wraps naturally.
- Active pill filled (`bg-link text-surface-1`); others outlined.
- TODO: replace year heading with a dropdown when the archive spans many years (currently fine as headings since archive is small).

### Selected-day preview (`PuzzleCard` reused)

- The existing `PuzzleCard` component is reused as the preview pane on day select.
- `tagline` carries the formatted date (`"Sunday, 26 April"`); for today, appended with `" · today's puzzle"`.
- `href` override → routes to `/` when the selected day is today (preserves home-page-as-today). PuzzleCard's `{...rest}` spread sits after the explicit href, so a passed `href` wins.
- Empty fallback (no day selected, or day has no puzzle): a `border-1` placeholder card with `"Pick a day to see its puzzle."` / `"No puzzle on this day."`.

### Always-selected behaviour

The page must **always have a day selected** (no awkward empty preview state on first load).

- URL has `day=` → use it (clamped to month bounds).
- Otherwise → first day of the active month with a puzzle (lowest day number).
- Active month: `?month=YYYY-MM` if present, else most recent month with puzzles.
- `buildMonthHref` clears the `day` param when switching months, so month clicks always re-trigger first-day auto-selection.

### Layout

**Calendar left, preview right** on desktop. Stacks vertically on mobile.

- `Main` width: `lg:max-w-5xl` (broke out of the prior `lg:max-w-xl` cap because the calendar + card needs the room).
- `<section>` uses `lg:grid-cols-2 lg:gap-fl-4`. Month strip spans both columns at top (`lg:col-span-full`).
- Sidebar `Panel` keeps its current contents (totals, difficulty breakdown, "Build a puzzle" CTA).

### URL shape

- `/puzzles?month=2026-04` — active month
- `/puzzles?month=2026-04&day=12` — deep-link a selected day
- `f-client-nav` on the `<section>` makes navigation feel SPA-ish without an island.

### Data model

Critical: puzzles are positioned in the calendar by **release date**, computed from `number` (day-of-year) plus the year of `createdAt`. The `createdAt` timestamp alone is the file-save time and doesn't reflect when the puzzle is published — using it directly causes most of a month's puzzles to collapse onto a single day.

Helpers added in `game/loader.ts`:

- `getReleaseDate(entry)` — `new Date(year, 0, entry.number)` where `year = createdAt.getFullYear()`. Returns `null` for entries without a `number` (tutorial/onboarding).
- `listPuzzleMonths()` — descending list of `{year, month}` pairs that have at least one available puzzle, computed from release dates.
- `listPuzzlesInMonth(year, month)` — `Map<dayOfMonth, PuzzleManifestEntry>` for the requested month.

`getAvailableEntries()` (existing) filters out unreleased puzzles (`number > dayOfYear`), so the calendar naturally shows only released days.

## Non-goals

- No infinite scroll — paginated month-by-month.
- No filters in v1 — dot encoding handles scannability.
- No search by puzzle name — archive is browsable, not searchable.
- No streak visualisation in this PR.
- No favourites/bookmarks.
- No thumbnails inside calendar cells (PuzzleCard preview keeps the existing thumbnail).
- **No post-solve "Next unplayed" continuation flow** — separate topic (celebration dialog, solve handler, home-page flow). Own branch.

## Follow-up branches

- **Year dropdown** — replace the static year headings when the archive spans multiple years.
- **Post-solve continuation** — "Next unplayed" CTA in the celebration dialog, server-side computation of the nearest unplayed neighbour. Applies after both archive and home-page solves.
- **Filter pills** — only if archive scale demands them.
- **Streak visualisation** — explicit streak indicators on the calendar.

## Files touched

- `game/loader.ts` — added `getReleaseDate`, `listPuzzleMonths`, `listPuzzlesInMonth`.
- `lib/locale.ts` (new) — `getFirstDayOfWeek` and `pickLocale` (Accept-Language → tag).
- `components/calendar-grid.tsx` (new) — server-rendered grid; locale-aware first day; fixed-height cells; outline-based selection ring; dot encoding (hollow ring unplayed / filled ui-1 solved / filled ui-2 optimal).
- `components/month-strip.tsx` (new) — year-grouped wrapping pill list.
- `routes/puzzles/index.tsx` — handler computes active month + always-selected day; layout split.
- `routes/puzzles/_e2e/archives_test.ts` & `archives-page.ts` — rewritten for the new flow (heading + click-day-then-card-to-navigate).

## Inspiration

- Google Calendar month view (mobile reference shared by user)
- NYT Crossword / Connections Companion archive (calendar + completion stars)
- Puzzmo shelf-by-difficulty (rejected — calendar wins for daily cadence)

## Known issues / TODOs

- E2E test `archives — clicking the selected-day detail navigates to the puzzle` failed on the previous run; selector needs updating after the layout switch from `SelectedDayPanel` (now deleted) to `PuzzleCard`. The other two archive tests pass.
- `f-client-nav` adds `aria-current="page"` and `data-current="true"` to every `<a>` whose href shares the path — affects both the month pills (all month pills get `aria-current="page"`) and gridcell day anchors. Not a blocker but means tests can't rely on `aria-current` to identify "the active month/day". Use the explicit `bg-link` class on the active month pill or the URL itself for selectors.
<!-- spec:end -->

## Demo

<!-- screenshots / screen recording here -->

https://github.com/user-attachments/assets/554891f0-b51b-4974-b8d7-c2c474c0790f
