### PR TITLE
Use default month when no puzzle page date query

### DIFF
--- a/components/month-strip.tsx
+++ b/components/month-strip.tsx
@@ -29,8 +29,6 @@ type Props = {
 };
 
 export function MonthStrip({ href, today, selectedDate }: Props) {
-  const date = getArchiveDate(href.value);
-
   return (
     <div className="flex max-sm:overflow-x-auto -mx-1 px-1 -my-1 py-1">
       <nav
@@ -43,7 +41,7 @@ export function MonthStrip({ href, today, selectedDate }: Props) {
 
           if (isFuture) return null;
 
-          const isActive = date?.month === idx + 1;
+          const isActive = selectedDate.month === idx + 1;
 
           return (
             <a

--- a/components/month-strip.tsx
+++ b/components/month-strip.tsx
@@ -1,8 +1,6 @@
 import { Signal } from "@preact/signals";
 import { clsx } from "clsx/lite";
 
-import { getArchiveDate } from "#/game/url.ts";
-
 type MonthStripProps = {
   href: string;
 };

--- a/routes/puzzles/index.tsx
+++ b/routes/puzzles/index.tsx
@@ -49,6 +49,7 @@ export const handler = define.handlers<PageData>({
       easy: 0,
       medium: 0,
       hard: 0,
+      ultra: 0,
     };
 
     for (const entry of entries) {


### PR DESCRIPTION
Simple fix, use the selectedDate in month strip for active month
## Demo

<img width="1226" height="829" alt="Screenshot 2026-04-27 at 21 41 04" src="https://github.com/user-attachments/assets/cebfde44-e08b-4896-84cd-0cd29874b522" />