### PR TITLE
Better back handling

### DIFF
--- a/game/date.ts
+++ b/game/date.ts
@@ -1,3 +1,5 @@
+import type { Puzzle } from "#/game/types.ts";
+
 const ONE_DAY_MS = 1000 * 60 * 60 * 24;
 
 /**
@@ -8,4 +10,13 @@ export function getDayOfYear(date: Date | Temporal.PlainDate): number {
 
   const firstDayOfYear = new Date(date.getFullYear(), 0, 0);
   return Math.floor((date.getTime() - firstDayOfYear.getTime()) / ONE_DAY_MS);
+}
+
+/**
+ * True when the puzzle's `number` matches today's day-of-year. Returns false
+ * for entries without a `number` (tutorial / onboarding).
+ */
+export function isTodaysPuzzle(puzzle: Pick<Puzzle, "number">): boolean {
+  return puzzle.number !== undefined &&
+    puzzle.number === getDayOfYear(new Date());
 }

--- a/game/url.ts
+++ b/game/url.ts
@@ -6,7 +6,13 @@ import {
   encodeMoves,
   encodePosition,
 } from "#/game/strings.ts";
-import { DIFFICULTIES, Difficulty, Move, Position } from "#/game/types.ts";
+import {
+  DIFFICULTIES,
+  Difficulty,
+  Move,
+  Position,
+  Puzzle,
+} from "#/game/types.ts";
 
 /**
  * All state needed to represent the current game
@@ -240,4 +246,19 @@ export function getArchiveDate(
   } catch {
     throw new Error("Unable to parse archive date");
   }
+}
+
+/**
+ * Returns the archive URL that lands on this puzzle's release date,
+ * or null for entries without a `number` (tutorial / onboarding).
+ * Release date = day-of-year (`number`) within the year of `createdAt`.
+ */
+export function getPuzzleArchiveHref(puzzle: Puzzle): string | null {
+  if (puzzle.number === undefined) return null;
+  const releaseDate = new Temporal.PlainDate(
+    puzzle.createdAt.getFullYear(),
+    1,
+    1,
+  ).add({ days: puzzle.number - 1 });
+  return `/puzzles?date=${releaseDate.toString()}`;
 }

--- a/islands/celebration-dialog.tsx
+++ b/islands/celebration-dialog.tsx
@@ -30,9 +30,12 @@ type Props = {
   puzzle: Signal<Puzzle>;
   stats: PuzzleStats;
   userStats?: UserStats | null;
+  back?: { href: string; label: string };
 };
 
-export function CelebrationDialog({ href, puzzle, stats, userStats }: Props) {
+export function CelebrationDialog(
+  { href, puzzle, stats, userStats, back }: Props,
+) {
   const [copied, setCopied] = useState(false);
 
   const liveStats = useSignal<CelebrateStats | null>(null);
@@ -171,8 +174,8 @@ export function CelebrationDialog({ href, puzzle, stats, userStats }: Props) {
           <a href={getResetHref(href.value)} className="text-text-2 text-1">
             Start over
           </a>
-          <a href="/" className="text-text-2 text-1">
-            Home
+          <a href={back?.href ?? "/"} className="text-text-2 text-1">
+            {back?.label ?? "Home"}
           </a>
         </div>
       </div>

--- a/islands/celebration-dialog.tsx
+++ b/islands/celebration-dialog.tsx
@@ -30,7 +30,7 @@ type Props = {
   puzzle: Signal<Puzzle>;
   stats: PuzzleStats;
   userStats?: UserStats | null;
-  back?: { href: string; label: string };
+  back: { href: string; label: string };
 };
 
 export function CelebrationDialog(
@@ -174,8 +174,8 @@ export function CelebrationDialog(
           <a href={getResetHref(href.value)} className="text-text-2 text-1">
             Start over
           </a>
-          <a href={back?.href ?? "/"} className="text-text-2 text-1">
-            {back?.label ?? "Home"}
+          <a href={back.href} className="text-text-2 text-1">
+            {back.label}
           </a>
         </div>
       </div>

--- a/routes/puzzles/[slug]/index.tsx
+++ b/routes/puzzles/[slug]/index.tsx
@@ -12,11 +12,12 @@ import { saveSolution } from "#/db/solutions.ts";
 import { setUser } from "#/db/user.ts";
 import { isValidSolution, resolveMoves } from "#/game/board.ts";
 import { getHintCount } from "#/game/cookies.ts";
+import { isTodaysPuzzle } from "#/game/date.ts";
 import { assessSkillLevel } from "#/game/skill.ts";
 import { defaultPuzzleStats } from "#/game/stats.ts";
 import type { UserStats } from "#/game/streak.ts";
 import { Move, Puzzle, PuzzleStats } from "#/game/types.ts";
-import { decodeState } from "#/game/url.ts";
+import { decodeState, getPuzzleArchiveHref } from "#/game/url.ts";
 import { AutoPostSolution } from "#/islands/auto-post-solution.tsx";
 import Board from "#/islands/board.tsx";
 import { CelebrationDialog } from "#/islands/celebration-dialog.tsx";
@@ -143,10 +144,17 @@ export default define.page<typeof handler>(function PuzzleDetails(props) {
 
   const url = new URL(props.req.url);
 
+  const back = isTodaysPuzzle(props.data.puzzle)
+    ? { href: "/", label: "Home" }
+    : {
+      href: getPuzzleArchiveHref(props.data.puzzle) ?? "/",
+      label: "Archives",
+    };
+
   return (
     <>
       <Main>
-        <Header url={url} back={{ href: "/" }} share />
+        <Header url={url} back={{ href: back.href }} share />
 
         <div className="flex items-center justify-between gap-fl-1 mt-2 flex-wrap">
           <h1 className="text-6 text-brand leading-tight">
@@ -218,6 +226,7 @@ export default define.page<typeof handler>(function PuzzleDetails(props) {
         puzzle={puzzle}
         stats={props.data.puzzleStats}
         userStats={props.data.userStats}
+        back={back}
       />
 
       {/* Client-side auto-post for named users */}

--- a/routes/puzzles/[slug]/solutions/[solutionId]/index.tsx
+++ b/routes/puzzles/[slug]/solutions/[solutionId]/index.tsx
@@ -49,14 +49,14 @@ export default define.page<typeof handler>(function SolutionReplayPage(props) {
   const href = useSignal(props.url.href);
   const mode = useSignal<"replay">("replay");
   const url = new URL(props.req.url);
-  const solutionsHref = `/puzzles/${props.data.puzzle.slug}/solutions`;
+  const backHref = `/puzzles/${props.data.puzzle.slug}/solutions`;
 
   return (
     <>
       <Main>
         <Header
           url={url}
-          back={{ href: solutionsHref }}
+          back={{ href: backHref }}
           share={{ params: true }}
         />
 

--- a/routes/puzzles/[slug]/solutions/index.tsx
+++ b/routes/puzzles/[slug]/solutions/index.tsx
@@ -75,6 +75,7 @@ export default define.page<typeof handler>(function SolutionsListPage(props) {
   const { groups, extraGroup, userCanonicalKeys } = props.data;
   const minMoves = props.data.puzzle.minMoves;
   const solutionsHref = `/puzzles/${props.data.puzzle.slug}/solutions`;
+  const backHref = `/puzzles/${props.data.puzzle.slug}`;
 
   const visibleGroups: (CanonicalGroup | null)[] = extraGroup
     ? [...groups.slice(0, 5), null, extraGroup]
@@ -85,7 +86,7 @@ export default define.page<typeof handler>(function SolutionsListPage(props) {
       <Main className="justify-stretch min-h-96">
         <Header
           url={url}
-          back={{ href: "/" }}
+          back={{ href: backHref }}
         />
 
         <div className="flex items-center justify-between mt-2 flex-wrap gap-fl-1">

--- a/routes/puzzles/index.tsx
+++ b/routes/puzzles/index.tsx
@@ -49,6 +49,7 @@ export const handler = define.handlers<PageData>({
       easy: 0,
       medium: 0,
       hard: 0,
+      ultra: 0,
     };
 
     for (const entry of entries) {

--- a/spec.md
+++ b/spec.md
@@ -1,119 +1,39 @@
-# Archive revamp — calendar view
+# Back arrow & celebration exit: split today vs archived
 
 ## Problem
 
-The previous archive (`/puzzles`) was a paginated 6-per-page card grid sorted by puzzle number. Clunky and slow to explore: cards sparse, no filters, "what haven't I played" required scanning every page.
+The back arrow on every puzzle page hardcodes `href="/"`, and the
+CelebrationDialog has a hardcoded "Home" tertiary link. For archived puzzles
+this is wrong twice: players exploring the archive get bounced to the home page
+both via the header back arrow and via the dialog after solving. Worse, the
+archive landing page lands on *today* rather than the day they were browsing —
+re-finding their place is friction every time.
 
 ## Approach
 
-Replaced the card grid with a **month-paginated calendar view**, inspired by Google Calendar's month view. Days are minimal cells with dots indicating play state. A wrapping list of months grouped by year drives navigation. Selecting a day populates a `PuzzleCard` preview to the right (desktop) or below (mobile); tapping the card opens the puzzle.
+Compute a single "back" target on the puzzle page and pass it to both the
+header and the CelebrationDialog:
 
-### Design principle: progressive disclosure
+- `puzzle.number === getDayOfYear(today)` → `{ href: "/", label: "Home" }`
+- otherwise (archived) → `{ href: "/puzzles?date=YYYY-MM-DD", label: "Archives" }`
+  where the date is the puzzle's release date (year of `createdAt` + day-of-year
+  from `number`). The archive page already reads `?date=YYYY-MM-DD` via
+  `getArchiveDate`, so it lands on the correct calendar day.
+- no `number` (tutorial / onboarding entries) → `{ href: "/", label: "Home" }`
 
-The grid is the **scan layer** — intentionally minimal so the eye can sweep a whole month. The preview pane is the **inspect layer** — anything richer than a dot belongs there.
+`getPuzzleArchiveHref(puzzle)` lives in `game/url.ts` next to `getArchiveDate`,
+so the read and write sides of the date param sit together. Returns `null` when
+the puzzle has no `number`.
 
-- Grid cells carry only the cheapest signal: day number + tiny play-state dot.
-- Anything richer (puzzle name, difficulty, move count, thumbnail) lives in the `PuzzleCard` preview.
-- Future additions (streak badges, "new this week" markers) default to the preview unless they materially improve scanning.
-
-### Calendar grid (`components/calendar-grid.tsx`)
-
-- 7-column month grid; **first day of week derived from user locale** via `Intl.Locale(locale).getWeekInfo().firstDay`, read server-side from `Accept-Language` (fallback Monday). Helper: `lib/locale.ts`.
-- **All days of the month render**, regardless of puzzle availability — empty/future days are dimmed, non-interactive cells.
-- **No weekday header row** (Mon/Tue/…) — weekday-of-cell isn't meaningful in a puzzle archive.
-- **Fixed cell height** (`h-14`) so cells don't jump when state changes.
-- Selection ring uses `outline` (not `ring` / `border`) so it doesn't shift layout.
-- Cell content:
-  - Day number (large, neutral; dimmed `text-text-2` when no puzzle).
-  - A small dot below, encoding play state — only completed/perfect days are marked:
-    - **Solved, not optimal** → filled `bg-ui-1` (matches `ph-check` pill on cards).
-    - **Solved, optimal** → filled `bg-ui-2` (matches `ph-trophy` pill on cards).
-    - **Anything else (unplayed or empty)** → no dot (invisible spacer reserves space).
-- Today's number gets a filled accent circle behind it (matches Google Calendar reference). State dot still applies underneath.
-- **Difficulty intentionally not encoded in the grid.** It surfaces in the preview pane only — keeps grid vocabulary minimal and aligns with progressive disclosure.
-
-### Month navigation (`components/month-strip.tsx`)
-
-- **Wrapping list of month pills, grouped by year.** Each year has a heading (`{year}`) and pills for months that have at least one published puzzle.
-- No horizontal scroll, no autofocus tricks — wraps naturally.
-- Active pill filled (`bg-link text-surface-1`); others outlined.
-- TODO: replace year heading with a dropdown when the archive spans many years (currently fine as headings since archive is small).
-
-### Selected-day preview (`PuzzleCard` reused)
-
-- The existing `PuzzleCard` component is reused as the preview pane on day select.
-- `tagline` carries the formatted date (`"Sunday, 26 April"`); for today, appended with `" · today's puzzle"`.
-- `href` override → routes to `/` when the selected day is today (preserves home-page-as-today). PuzzleCard's `{...rest}` spread sits after the explicit href, so a passed `href` wins.
-- Empty fallback (no day selected, or day has no puzzle): a `border-1` placeholder card with `"Pick a day to see its puzzle."` / `"No puzzle on this day."`.
-
-### Always-selected behaviour
-
-The page must **always have a day selected** (no awkward empty preview state on first load).
-
-- URL has `day=` → use it (clamped to month bounds).
-- Otherwise → first day of the active month with a puzzle (lowest day number).
-- Active month: `?month=YYYY-MM` if present, else most recent month with puzzles.
-- `buildMonthHref` clears the `day` param when switching months, so month clicks always re-trigger first-day auto-selection.
-
-### Layout
-
-**Calendar left, preview right** on desktop. Stacks vertically on mobile.
-
-- `Main` width: `lg:max-w-5xl` (broke out of the prior `lg:max-w-xl` cap because the calendar + card needs the room).
-- `<section>` uses `lg:grid-cols-2 lg:gap-fl-4`. Month strip spans both columns at top (`lg:col-span-full`).
-- Sidebar `Panel` keeps its current contents (totals, difficulty breakdown, "Build a puzzle" CTA).
-
-### URL shape
-
-- `/puzzles?month=2026-04` — active month
-- `/puzzles?month=2026-04&day=12` — deep-link a selected day
-- `f-client-nav` on the `<section>` makes navigation feel SPA-ish without an island.
-
-### Data model
-
-Critical: puzzles are positioned in the calendar by **release date**, computed from `number` (day-of-year) plus the year of `createdAt`. The `createdAt` timestamp alone is the file-save time and doesn't reflect when the puzzle is published — using it directly causes most of a month's puzzles to collapse onto a single day.
-
-Helpers added in `game/loader.ts`:
-
-- `getReleaseDate(entry)` — `new Date(year, 0, entry.number)` where `year = createdAt.getFullYear()`. Returns `null` for entries without a `number` (tutorial/onboarding).
-- `listPuzzleMonths()` — descending list of `{year, month}` pairs that have at least one available puzzle, computed from release dates.
-- `listPuzzlesInMonth(year, month)` — `Map<dayOfMonth, PuzzleManifestEntry>` for the requested month.
-
-`getAvailableEntries()` (existing) filters out unreleased puzzles (`number > dayOfYear`), so the calendar naturally shows only released days.
+CelebrationDialog accepts an optional `back` prop (`{ href, label }`) and
+defaults to `Home` / `/` for any caller that doesn't pass one — the puzzle page
+is currently the only consumer.
 
 ## Non-goals
 
-- No infinite scroll — paginated month-by-month.
-- No filters in v1 — dot encoding handles scannability.
-- No search by puzzle name — archive is browsable, not searchable.
-- No streak visualisation in this PR.
-- No favourites/bookmarks.
-- No thumbnails inside calendar cells (PuzzleCard preview keeps the existing thumbnail).
-- **No post-solve "Next unplayed" continuation flow** — separate topic (celebration dialog, solve handler, home-page flow). Own branch.
-
-## Follow-up branches
-
-- **Year dropdown** — replace the static year headings when the archive spans multiple years.
-- **Post-solve continuation** — "Next unplayed" CTA in the celebration dialog, server-side computation of the nearest unplayed neighbour. Applies after both archive and home-page solves.
-- **Filter pills** — only if archive scale demands them.
-- **Streak visualisation** — explicit streak indicators on the calendar.
-
-## Files touched
-
-- `game/loader.ts` — added `getReleaseDate`, `listPuzzleMonths`, `listPuzzlesInMonth`.
-- `lib/locale.ts` (new) — `getFirstDayOfWeek` and `pickLocale` (Accept-Language → tag).
-- `components/calendar-grid.tsx` (new) — server-rendered grid; locale-aware first day; fixed-height cells; outline-based selection ring; dot encoding (hollow ring unplayed / filled ui-1 solved / filled ui-2 optimal).
-- `components/month-strip.tsx` (new) — year-grouped wrapping pill list.
-- `routes/puzzles/index.tsx` — handler computes active month + always-selected day; layout split.
-- `routes/puzzles/_e2e/archives_test.ts` & `archives-page.ts` — rewritten for the new flow (heading + click-day-then-card-to-navigate).
-
-## Inspiration
-
-- Google Calendar month view (mobile reference shared by user)
-- NYT Crossword / Connections Companion archive (calendar + completion stars)
-- Puzzmo shelf-by-difficulty (rejected — calendar wins for daily cadence)
-
-## Known issues / TODOs
-
-- E2E test `archives — clicking the selected-day detail navigates to the puzzle` failed on the previous run; selector needs updating after the layout switch from `SelectedDayPanel` (now deleted) to `PuzzleCard`. The other two archive tests pass.
-- `f-client-nav` adds `aria-current="page"` and `data-current="true"` to every `<a>` whose href shares the path — affects both the month pills (all month pills get `aria-current="page"`) and gridcell day anchors. Not a blocker but means tests can't rely on `aria-current` to identify "the active month/day". Use the explicit `bg-link` class on the active month pill or the URL itself for selectors.
+- "True" back navigation (remembering which archive month/filter the user came
+  from beyond the day). The day-precision URL is enough for the intended UX.
+- Back arrow split for solutions / og-image / clone subroutes — only the
+  puzzle detail page is affected.
+- Touching SolutionDialog — its dismissal path is structurally different
+  (name-entry flow, not a tertiary "leave" link).

--- a/spec.md
+++ b/spec.md
@@ -4,36 +4,39 @@
 
 The back arrow on every puzzle page hardcodes `href="/"`, and the
 CelebrationDialog has a hardcoded "Home" tertiary link. For archived puzzles
-this is wrong twice: players exploring the archive get bounced to the home page
-both via the header back arrow and via the dialog after solving. Worse, the
-archive landing page lands on *today* rather than the day they were browsing —
-re-finding their place is friction every time.
+this is wrong twice: players exploring the archive get bounced to the home
+page both via the header back arrow and via the dialog after solving. Worse,
+the archive landing page lands on *today* rather than the day they were
+browsing — re-finding their place is friction every time.
 
 ## Approach
 
-Compute a single "back" target on the puzzle page and pass it to both the
-header and the CelebrationDialog:
+Compute a single `back: { href, label }` on the puzzle page and pass it to
+both the header and the CelebrationDialog:
 
-- `puzzle.number === getDayOfYear(today)` → `{ href: "/", label: "Home" }`
-- otherwise (archived) → `{ href: "/puzzles?date=YYYY-MM-DD", label: "Archives" }`
+- today's daily puzzle → `{ href: "/", label: "Home" }`
+- archived daily puzzle → `{ href: "/puzzles?date=YYYY-MM-DD", label: "Archives" }`
   where the date is the puzzle's release date (year of `createdAt` + day-of-year
   from `number`). The archive page already reads `?date=YYYY-MM-DD` via
-  `getArchiveDate`, so it lands on the correct calendar day.
-- no `number` (tutorial / onboarding entries) → `{ href: "/", label: "Home" }`
+  `getArchiveDate`, so it lands on the correct calendar day — preserving the
+  user's place in the archive.
 
-`getPuzzleArchiveHref(puzzle)` lives in `game/url.ts` next to `getArchiveDate`,
-so the read and write sides of the date param sit together. Returns `null` when
-the puzzle has no `number`.
+Two new utilities:
 
-CelebrationDialog accepts an optional `back` prop (`{ href, label }`) and
-defaults to `Home` / `/` for any caller that doesn't pass one — the puzzle page
-is currently the only consumer.
+- `isTodaysPuzzle(puzzle)` in `game/date.ts` — pure predicate comparing
+  `puzzle.number` to today's day-of-year. Returns false for entries without a
+  `number`.
+- `getPuzzleArchiveHref(puzzle)` in `game/url.ts` — builds the archive URL
+  with the day param via `Temporal.PlainDate`. Sits next to `getArchiveDate`
+  so the read and write sides of the date param live together.
+
+CelebrationDialog now requires a `back` prop (no defensive defaults).
 
 ## Non-goals
 
-- "True" back navigation (remembering which archive month/filter the user came
-  from beyond the day). The day-precision URL is enough for the intended UX.
 - Back arrow split for solutions / og-image / clone subroutes — only the
   puzzle detail page is affected.
 - Touching SolutionDialog — its dismissal path is structurally different
   (name-entry flow, not a tertiary "leave" link).
+- Contextual `aria-label` on the header back arrow ("Back to archives" vs
+  "Back to home"). Currently a generic "Back" — left for a follow-up.


### PR DESCRIPTION
<!-- spec:start -->
# Back arrow & celebration exit: split today vs archived

## Problem

The back arrow on every puzzle page hardcodes `href="/"`, and the
CelebrationDialog has a hardcoded "Home" tertiary link. For archived puzzles
this is wrong twice: players exploring the archive get bounced to the home
page both via the header back arrow and via the dialog after solving. Worse,
the archive landing page lands on *today* rather than the day they were
browsing — re-finding their place is friction every time.

## Approach

Compute a single `back: { href, label }` on the puzzle page and pass it to
both the header and the CelebrationDialog:

- today's daily puzzle → `{ href: "/", label: "Home" }`
- archived daily puzzle → `{ href: "/puzzles?date=YYYY-MM-DD", label: "Archives" }`
  where the date is the puzzle's release date (year of `createdAt` + day-of-year
  from `number`). The archive page already reads `?date=YYYY-MM-DD` via
  `getArchiveDate`, so it lands on the correct calendar day — preserving the
  user's place in the archive.

Two new utilities:

- `isTodaysPuzzle(puzzle)` in `game/date.ts` — pure predicate comparing
  `puzzle.number` to today's day-of-year. Returns false for entries without a
  `number`.
- `getPuzzleArchiveHref(puzzle)` in `game/url.ts` — builds the archive URL
  with the day param via `Temporal.PlainDate`. Sits next to `getArchiveDate`
  so the read and write sides of the date param live together.

CelebrationDialog now requires a `back` prop (no defensive defaults).

## Non-goals

- Back arrow split for solutions / og-image / clone subroutes — only the
  puzzle detail page is affected.
- Touching SolutionDialog — its dismissal path is structurally different
  (name-entry flow, not a tertiary "leave" link).
- Contextual `aria-label` on the header back arrow ("Back to archives" vs
  "Back to home"). Currently a generic "Back" — left for a follow-up.
<!-- spec:end -->

## Demo

<!-- screenshots / screen recording here -->

https://github.com/user-attachments/assets/dda27b18-35f2-4ac0-9a7c-9ccfb1e15e26


https://github.com/user-attachments/assets/090bc81a-623b-477c-8aae-0e4a9f5366ff
