### PR TITLE
Add recommended puzzles engine

### DIFF
--- a/game/recommendation.ts
+++ b/game/recommendation.ts
@@ -12,7 +12,7 @@ import type { SkillLevel } from "#/game/types.ts";
 
 /**
  * Picks the puzzle to recommend to the user — the "what should I play next"
- * answer shared between the home page card and the `/puzzles/random` redirect:
+ * answer shared between the home page card and the `/puzzles/recommended` redirect:
  *
  *  - new user (`skillLevel === null`) → tutorial puzzle (kind: "onboarding")
  *  - beginner with remaining onboarding → onboarding puzzle (kind: "onboarding")

--- a/game/recommendation.ts
+++ b/game/recommendation.ts
@@ -1,0 +1,71 @@
+import { getBestMoves } from "#/db/solutions.ts";
+import type { Solution } from "#/db/types.ts";
+import {
+  getAvailableEntries,
+  getLatestPuzzle,
+  getOnboardingPuzzle,
+  getPuzzle,
+  getRandomPuzzle,
+  getTutorialPuzzle,
+} from "#/game/loader.ts";
+import type { SkillLevel } from "#/game/types.ts";
+
+/**
+ * Picks the puzzle to recommend to the user — the "what should I play next"
+ * answer shared between the home page card and the `/puzzles/random` redirect:
+ *
+ *  - new user (`skillLevel === null`) → tutorial puzzle (kind: "onboarding")
+ *  - beginner with remaining onboarding → onboarding puzzle (kind: "onboarding")
+ *  - beginner who exhausted onboarding → falls through to random
+ *  - everything perfected → "loke" (the endgame puzzle, kind: "random")
+ *  - otherwise → random non-optimal puzzle of appropriate difficulty,
+ *    with today's daily excluded (kind: "random")
+ */
+export async function pickRecommendedPuzzle(
+  user: { skillLevel: SkillLevel | null },
+  solutions: Solution[],
+) {
+  if (user.skillLevel === null) {
+    const puzzle = await getTutorialPuzzle();
+    if (!puzzle) throw new Error("Unable to get tutorial puzzle");
+    return puzzle;
+  }
+
+  if (user.skillLevel === "beginner") {
+    const solvedSlugs = solutions.map((s) => s.puzzleSlug);
+    const puzzle = await getOnboardingPuzzle({ excludeSlugs: solvedSlugs });
+    if (!puzzle) throw new Error("Unable to get onboarding puzzle");
+    return puzzle;
+  }
+
+  const bestMoves = getBestMoves(solutions);
+  const entries = await getAvailableEntries();
+  const optimalSlugs = entries
+    .filter((entry) => bestMoves[entry.slug] === entry.minMoves)
+    .map((entry) => entry.slug);
+  const allPerfected = entries
+    .filter((entry) => entry.minMoves)
+    .every((entry) => optimalSlugs.includes(entry.slug));
+
+  if (allPerfected) {
+    const puzzle = await getPuzzle("loke");
+    if (!puzzle) throw new Error("Unable to get final puzzle");
+    return puzzle;
+  }
+
+  const dailyPuzzle = await getLatestPuzzle();
+  const excludeSlugs = [
+    ...(dailyPuzzle ? [dailyPuzzle.slug] : []),
+    ...optimalSlugs,
+  ];
+
+  const puzzle = await getRandomPuzzle({
+    excludeSlugs,
+    difficulty: user.skillLevel === "expert"
+      ? ["easy", "medium", "hard"]
+      : ["easy", "medium"],
+  });
+
+  if (!puzzle) throw new Error("Unable to get random puzzle");
+  return puzzle;
+}

--- a/islands/celebration-dialog.tsx
+++ b/islands/celebration-dialog.tsx
@@ -1,11 +1,10 @@
 import { useSignal } from "@preact/signals";
 import { type Signal } from "@preact/signals";
-import { useCallback, useEffect, useMemo, useState } from "preact/hooks";
+import { useEffect, useMemo } from "preact/hooks";
 
 import { addTraceParentHeader } from "#/client/trace-context.ts";
-import { Check, Icon, Ranking, ShareNetwork } from "#/components/icons.tsx";
+import { ArrowRight, Icon, Ranking } from "#/components/icons.tsx";
 import { isValidSolution, resolveMoves } from "#/game/board.ts";
-import { getShareText } from "#/game/share.ts";
 import { UserStats } from "#/game/streak.ts";
 import { Puzzle, PuzzleStats } from "#/game/types.ts";
 import { decodeState, getResetHref } from "#/game/url.ts";
@@ -36,8 +35,6 @@ type Props = {
 export function CelebrationDialog(
   { href, puzzle, stats, userStats, back }: Props,
 ) {
-  const [copied, setCopied] = useState(false);
-
   const liveStats = useSignal<CelebrateStats | null>(null);
   const statsFetched = useSignal(false);
 
@@ -104,30 +101,6 @@ export function CelebrationDialog(
     [moves.length, isNewPath, puzzle.value, activePuzzleStats, activeUserStats],
   );
 
-  const onShare = useCallback(async () => {
-    const origin = globalThis.location?.origin ?? "";
-    const { text, url } = getShareText({
-      origin,
-      puzzle: puzzle.value,
-      moveCount: moves.length,
-      stats: activePuzzleStats,
-    });
-
-    try {
-      if ("share" in navigator) {
-        await globalThis.navigator.share({ text, url });
-      } else {
-        await globalThis.navigator.clipboard.writeText(`${text}\n${url}`);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
-      }
-    } catch (err) {
-      if (err instanceof Error && err.name !== "AbortError") {
-        console.error("Share failed:", err);
-      }
-    }
-  }, [puzzle.value, moves.length, activePuzzleStats]);
-
   return (
     <Dialog open={isOpen}>
       <div className="flex flex-col gap-fl-2">
@@ -145,29 +118,18 @@ export function CelebrationDialog(
           <a
             href={`/puzzles/${puzzle.value.slug}/solutions`}
             className="btn flex-1 justify-center"
-            data-primary
-            autoFocus
           >
             <Icon icon={Ranking} /> See solves
           </a>
 
-          <button
-            type="button"
-            className="btn flex-1 hidden js:inline-flex"
-            onClick={onShare}
+          <a
+            href="/puzzles/random"
+            className="btn flex-1 justify-center"
+            data-primary
+            autoFocus
           >
-            {copied
-              ? (
-                <>
-                  <Icon icon={Check} /> Copied!
-                </>
-              )
-              : (
-                <>
-                  <Icon icon={ShareNetwork} /> Share
-                </>
-              )}
-          </button>
+            One more <Icon icon={ArrowRight} />
+          </a>
         </div>
 
         <div className="flex justify-center gap-fl-2 mt-1">

--- a/islands/celebration-dialog.tsx
+++ b/islands/celebration-dialog.tsx
@@ -123,7 +123,7 @@ export function CelebrationDialog(
           </a>
 
           <a
-            href="/puzzles/random"
+            href="/puzzles/recommended"
             className="btn flex-1 justify-center"
             data-primary
             autoFocus
@@ -133,9 +133,11 @@ export function CelebrationDialog(
         </div>
 
         <div className="flex justify-center gap-fl-2 mt-1">
-          <a href={getResetHref(href.value)} className="text-text-2 text-1">
-            Start over
-          </a>
+          {!isOptimal && (
+            <a href={getResetHref(href.value)} className="text-text-2 text-1">
+              Try again
+            </a>
+          )}
           <a href={back.href} className="text-text-2 text-1">
             {back.label}
           </a>

--- a/islands/solution-dialog.tsx
+++ b/islands/solution-dialog.tsx
@@ -5,7 +5,7 @@ import { useMemo, useState } from "preact/hooks";
 import { Icon, Spinner } from "#/components/icons.tsx";
 import { isValidSolution, resolveMoves } from "#/game/board.ts";
 import { Puzzle } from "#/game/types.ts";
-import { decodeState, getResetHref } from "#/game/url.ts";
+import { decodeState } from "#/game/url.ts";
 import { Dialog } from "#/islands/dialog.tsx";
 
 type Props = {
@@ -92,12 +92,7 @@ export function SolutionDialog(
             "max-md:justify-center",
           )}
         >
-          <a
-            href={getResetHref(href.value)}
-          >
-            Play again
-          </a>
-          <a href="/puzzles/random">
+          <a href="/puzzles/recommended">
             One more
           </a>
         </div>

--- a/islands/solution-dialog.tsx
+++ b/islands/solution-dialog.tsx
@@ -97,6 +97,9 @@ export function SolutionDialog(
           >
             Play again
           </a>
+          <a href="/puzzles/random">
+            One more
+          </a>
         </div>
 
         <button

--- a/routes/index.tsx
+++ b/routes/index.tsx
@@ -16,21 +16,15 @@ import { StatsSummary } from "#/components/stats-summary.tsx";
 import { define } from "#/core.ts";
 import { getBestMoves, listUserSolutions } from "#/db/solutions.ts";
 import { getUserStats } from "#/db/stats.ts";
-import {
-  getAvailableEntries,
-  getLatestPuzzle,
-  getOnboardingPuzzle,
-  getPuzzle,
-  getRandomPuzzle,
-} from "#/game/loader.ts";
+import { getLatestPuzzle } from "#/game/loader.ts";
+import { pickRecommendedPuzzle } from "#/game/recommendation.ts";
 import type { UserStats } from "#/game/streak.ts";
 import type { Puzzle } from "#/game/types.ts";
 import { withSpan } from "#/lib/tracing.ts";
 
 type PageData = {
   dailyPuzzle: Puzzle;
-  randomPuzzle: Puzzle | null;
-  onboardingPuzzle: Puzzle | null;
+  recommendedPuzzle: Puzzle;
   bestMoves: Record<string, number>;
   userStats: UserStats | null;
 };
@@ -55,41 +49,13 @@ export const handler = define.handlers<PageData>({
 
     if (!dailyPuzzle) throw new HttpError(500, "Unable to get daily puzzle");
 
-    const solvedSlugs = solutions.map((solution) => solution.puzzleSlug);
-
-    const onboardingPuzzle = user.skillLevel === "beginner"
-      ? await getOnboardingPuzzle({
-        excludeSlugs: solvedSlugs,
-      })
-      : null;
-
     const bestMoves = getBestMoves(solutions);
-    const entries = await getAvailableEntries();
-    const optimalSlugs = entries
-      .filter((entry) => bestMoves[entry.slug] === entry.minMoves)
-      .map((entry) => entry.slug);
-    const allPerfected = entries
-      .filter((entry) => entry.minMoves)
-      .every((entry) => optimalSlugs.includes(entry.slug));
-
-    let randomPuzzle: Puzzle | null = null;
-    if (user.skillLevel !== null && !onboardingPuzzle) {
-      randomPuzzle = allPerfected
-        ? await getPuzzle("loke")
-        : await getRandomPuzzle({
-          excludeSlugs: [dailyPuzzle.slug, ...optimalSlugs],
-          difficulty: user.skillLevel === "expert"
-            ? ["easy", "medium", "hard"]
-            : ["easy", "medium"],
-        });
-    }
-
+    const recommendedPuzzle = await pickRecommendedPuzzle(user, solutions);
     const userStats = await getUserStats(ctx.state.userId, solutions);
 
     return page({
       dailyPuzzle,
-      onboardingPuzzle,
-      randomPuzzle,
+      recommendedPuzzle,
       bestMoves,
       userStats: userStats.totalSolves > 0 ? userStats : null,
     });
@@ -99,8 +65,12 @@ export const handler = define.handlers<PageData>({
 export default define.page<typeof handler>(function Home(ctx) {
   const url = new URL(ctx.req.url);
 
-  const { dailyPuzzle, randomPuzzle, onboardingPuzzle, bestMoves, userStats } =
-    ctx.data;
+  const {
+    dailyPuzzle,
+    recommendedPuzzle,
+    bestMoves,
+    userStats,
+  } = ctx.data;
   const { user } = ctx.state;
 
   return (
@@ -163,20 +133,20 @@ export default define.page<typeof handler>(function Home(ctx) {
                 </a>
               )}
 
-              {onboardingPuzzle && (
+              {user.skillLevel && recommendedPuzzle.onboardingLevel && (
                 <PuzzleCard
-                  puzzle={onboardingPuzzle}
-                  tagline={onboardingPuzzle.onboardingLevel === 2
+                  puzzle={recommendedPuzzle}
+                  tagline={recommendedPuzzle.onboardingLevel === 2
                     ? "Starter puzzle"
                     : "Quick puzzle"}
                 />
               )}
 
-              {randomPuzzle && (
+              {user.skillLevel && !recommendedPuzzle.onboardingLevel && (
                 <PuzzleCard
-                  puzzle={randomPuzzle}
+                  puzzle={recommendedPuzzle}
                   tagline="Random puzzle"
-                  bestMoves={bestMoves[randomPuzzle.slug]}
+                  bestMoves={bestMoves[recommendedPuzzle.slug]}
                 />
               )}
             </li>

--- a/routes/puzzles/random/index.ts
+++ b/routes/puzzles/random/index.ts
@@ -1,0 +1,28 @@
+import { define } from "#/core.ts";
+import { listUserSolutions } from "#/db/solutions.ts";
+import { pickRecommendedPuzzle } from "#/game/recommendation.ts";
+
+/**
+ * Picks the recommended puzzle for the current user (same logic as the home
+ * page card) and 303s to `/puzzles/<slug>`. Falls back to `/` when nothing
+ * can be recommended — new users without a skill level, or fully-perfected
+ * players when "loke" can't be loaded.
+ */
+export const handler = define.handlers({
+  async GET(ctx) {
+    const solutions = await listUserSolutions(ctx.state.userId, {
+      limit: "max",
+    });
+
+    const recommended = await pickRecommendedPuzzle(
+      ctx.state.user,
+      solutions,
+    );
+
+    const target = recommended
+      ? new URL(`/puzzles/${recommended.puzzle.slug}`, ctx.url)
+      : new URL("/", ctx.url);
+
+    return Response.redirect(target, 303);
+  },
+});

--- a/routes/puzzles/recommended/index.ts
+++ b/routes/puzzles/recommended/index.ts
@@ -20,7 +20,7 @@ export const handler = define.handlers({
     );
 
     const target = recommended
-      ? new URL(`/puzzles/${recommended.puzzle.slug}`, ctx.url)
+      ? new URL(`/puzzles/${recommended.slug}`, ctx.url)
       : new URL("/", ctx.url);
 
     return Response.redirect(target, 303);

--- a/spec.md
+++ b/spec.md
@@ -1,0 +1,63 @@
+# Chain games: `/puzzles/random` redirect + dialog buttons
+
+## Problem
+
+After solving a puzzle, players have to navigate back home (or to the archive)
+to find the next thing to play. The flow is friction for engaged players who
+just want to keep going. The home page already picks a "recommended" puzzle
+for them — that same logic should be reachable from inside the post-solve
+dialogs.
+
+## Approach
+
+Two pieces:
+
+1. **`/puzzles/random` redirect route** — a server-side handler that picks the
+   recommended puzzle for the user and 303s to `/puzzles/<slug>`. Works
+   without JavaScript (it's a plain link target). Falls back to `/` when
+   nothing can be recommended (new user with no skill level, or every puzzle
+   perfected and "loke" can't be loaded).
+2. **`pickRecommendedPuzzle(user, solutions)`** in a new
+   `game/recommendation.ts` — extracts the home-page picker so both the home
+   handler and the redirect route share one source of truth. Logic:
+   - new user (`skillLevel === null`) → tutorial puzzle (filling the gap
+     where the previous home logic returned nothing for new users)
+   - beginner → onboarding puzzle, falling through to random when exhausted
+   - everything perfected → "loke" (endgame puzzle)
+   - otherwise → random non-optimal puzzle of appropriate difficulty,
+     today's daily always excluded
+
+The home handler is refactored to call `pickRecommendedPuzzle` instead of
+inlining the decision tree. The home UI gates the new onboarding/recommended
+cards behind `skillLevel !== null` so the existing "Learn the basics" CTA
+remains the sole signal for brand-new players — the tutorial recommendation
+is consumed by the `/puzzles/random` redirect, not the home cards.
+
+Dialog buttons added in `SolutionDialog` and `CelebrationDialog` linking to
+`/puzzles/random`. Plain `<a>` tags, no client-side state, no fetch — the
+navigation does all the work.
+
+In `CelebrationDialog` the **share** CTA is removed and its slot is taken
+over by the new "Another puzzle" primary action. Share usage is effectively
+zero today, and the chaining CTA earns the prime real-estate while the game
+still builds critical mass through word of mouth. Share can come back later
+once organic loops are stronger; the underlying `getShareText` helper stays
+available.
+
+## Non-goals
+
+- A general "next puzzle" API endpoint returning JSON. Navigation-shaped is
+  enough for the chaining UX; an API-shape would invite client-side state
+  juggling that this feature doesn't need.
+- Surfacing "another puzzle" on the home page or archive list. The button
+  only appears in post-solve dialogs (the moment chaining matters).
+- Changing the home page's tagline / `bestMoves` wiring for the picked puzzle —
+  the refactor preserves existing behaviour byte-for-byte.
+- Per-call exclusion (e.g. "skip the puzzle I just solved"). Optimal solves
+  are already filtered out of the random pool; non-optimal repeats are rare
+  enough not to warrant a `?exclude=` param's complexity.
+- Celebration transition / animation buildup before the dialog opens
+  (separate follow-up).
+- Skipping name submission for anonymous players who click "Another puzzle"
+  from `SolutionDialog` — that's the scoreboard-opt-out feature, deferred.
+  The link bypasses Save as a side effect; acceptable for now.

--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,4 @@
-# Chain games: `/puzzles/random` redirect + dialog buttons
+# Chain games: `/puzzles/recommended` redirect + dialog buttons
 
 ## Problem
 
@@ -12,7 +12,7 @@ dialogs.
 
 Two pieces:
 
-1. **`/puzzles/random` redirect route** — a server-side handler that picks the
+1. **`/puzzles/recommended` redirect route** — a server-side handler that picks the
    recommended puzzle for the user and 303s to `/puzzles/<slug>`. Works
    without JavaScript (it's a plain link target). Falls back to `/` when
    nothing can be recommended (new user with no skill level, or every puzzle
@@ -31,10 +31,10 @@ The home handler is refactored to call `pickRecommendedPuzzle` instead of
 inlining the decision tree. The home UI gates the new onboarding/recommended
 cards behind `skillLevel !== null` so the existing "Learn the basics" CTA
 remains the sole signal for brand-new players — the tutorial recommendation
-is consumed by the `/puzzles/random` redirect, not the home cards.
+is consumed by the `/puzzles/recommended` redirect, not the home cards.
 
 Dialog buttons added in `SolutionDialog` and `CelebrationDialog` linking to
-`/puzzles/random`. Plain `<a>` tags, no client-side state, no fetch — the
+`/puzzles/recommended`. Plain `<a>` tags, no client-side state, no fetch — the
 navigation does all the work.
 
 In `CelebrationDialog` the **share** CTA is removed and its slot is taken


### PR DESCRIPTION
<!-- spec:start -->
# Chain games: `/puzzles/recommended` redirect + dialog buttons

## Problem

After solving a puzzle, players have to navigate back home (or to the archive)
to find the next thing to play. The flow is friction for engaged players who
just want to keep going. The home page already picks a "recommended" puzzle
for them — that same logic should be reachable from inside the post-solve
dialogs.

## Approach

Two pieces:

1. **`/puzzles/recommended` redirect route** — a server-side handler that picks the
   recommended puzzle for the user and 303s to `/puzzles/<slug>`. Works
   without JavaScript (it's a plain link target). Falls back to `/` when
   nothing can be recommended (new user with no skill level, or every puzzle
   perfected and "loke" can't be loaded).
2. **`pickRecommendedPuzzle(user, solutions)`** in a new
   `game/recommendation.ts` — extracts the home-page picker so both the home
   handler and the redirect route share one source of truth. Logic:
   - new user (`skillLevel === null`) → tutorial puzzle (filling the gap
     where the previous home logic returned nothing for new users)
   - beginner → onboarding puzzle, falling through to random when exhausted
   - everything perfected → "loke" (endgame puzzle)
   - otherwise → random non-optimal puzzle of appropriate difficulty,
     today's daily always excluded

The home handler is refactored to call `pickRecommendedPuzzle` instead of
inlining the decision tree. The home UI gates the new onboarding/recommended
cards behind `skillLevel !== null` so the existing "Learn the basics" CTA
remains the sole signal for brand-new players — the tutorial recommendation
is consumed by the `/puzzles/recommended` redirect, not the home cards.

Dialog buttons added in `SolutionDialog` and `CelebrationDialog` linking to
`/puzzles/recommended`. Plain `<a>` tags, no client-side state, no fetch — the
navigation does all the work.

In `CelebrationDialog` the **share** CTA is removed and its slot is taken
over by the new "Another puzzle" primary action. Share usage is effectively
zero today, and the chaining CTA earns the prime real-estate while the game
still builds critical mass through word of mouth. Share can come back later
once organic loops are stronger; the underlying `getShareText` helper stays
available.

## Non-goals

- A general "next puzzle" API endpoint returning JSON. Navigation-shaped is
  enough for the chaining UX; an API-shape would invite client-side state
  juggling that this feature doesn't need.
- Surfacing "another puzzle" on the home page or archive list. The button
  only appears in post-solve dialogs (the moment chaining matters).
- Changing the home page's tagline / `bestMoves` wiring for the picked puzzle —
  the refactor preserves existing behaviour byte-for-byte.
- Per-call exclusion (e.g. "skip the puzzle I just solved"). Optimal solves
  are already filtered out of the random pool; non-optimal repeats are rare
  enough not to warrant a `?exclude=` param's complexity.
- Celebration transition / animation buildup before the dialog opens
  (separate follow-up).
- Skipping name submission for anonymous players who click "Another puzzle"
  from `SolutionDialog` — that's the scoreboard-opt-out feature, deferred.
  The link bypasses Save as a side effect; acceptable for now.
<!-- spec:end -->

## Demo

<!-- screenshots / screen recording here -->

https://github.com/user-attachments/assets/fe784c3e-6a98-4373-b258-1ab635ab1020


https://github.com/user-attachments/assets/654a4682-7f33-4d6b-84d8-703dab188965
