### PR TITLE
Fix 500 error when all puzzles are perfected

### DIFF
--- a/game/recommendation.ts
+++ b/game/recommendation.ts
@@ -17,7 +17,7 @@ import type { SkillLevel } from "#/game/types.ts";
  *  - new user (`skillLevel === null`) → tutorial puzzle (kind: "onboarding")
  *  - beginner with remaining onboarding → onboarding puzzle (kind: "onboarding")
  *  - beginner who exhausted onboarding → falls through to random
- *  - everything perfected → "loke" (the endgame puzzle, kind: "random")
+ *  - everything perfected (or only today's daily left) → "loke" (kind: "random")
  *  - otherwise → random non-optimal puzzle of appropriate difficulty,
  *    with today's daily excluded (kind: "random")
  */
@@ -39,21 +39,27 @@ export async function pickRecommendedPuzzle(
   }
 
   const bestMoves = getBestMoves(solutions);
-  const entries = await getAvailableEntries();
+  const [entries, dailyPuzzle] = await Promise.all([
+    getAvailableEntries(),
+    getLatestPuzzle(),
+  ]);
   const optimalSlugs = entries
     .filter((entry) => bestMoves[entry.slug] === entry.minMoves)
     .map((entry) => entry.slug);
-  const allPerfected = entries
-    .filter((entry) => entry.minMoves)
+
+  // Endgame: everything available (besides today's daily, which is shown on its
+  // own card) is perfected. Recommend loke even if today's daily is still
+  // unsolved — otherwise excludeSlugs covers every puzzle and we 500.
+  const nothingLeftToPerfect = entries
+    .filter((entry) => entry.minMoves && entry.slug !== dailyPuzzle?.slug)
     .every((entry) => optimalSlugs.includes(entry.slug));
 
-  if (allPerfected) {
+  if (nothingLeftToPerfect) {
     const puzzle = await getPuzzle("loke");
     if (!puzzle) throw new Error("Unable to get final puzzle");
     return puzzle;
   }
 
-  const dailyPuzzle = await getLatestPuzzle();
   const excludeSlugs = [
     ...(dailyPuzzle ? [dailyPuzzle.slug] : []),
     ...optimalSlugs,


### PR DESCRIPTION
See issue https://github.com/kasperstorgaard/skub/issues/203

Makes sure the the Loke logic does not take the daily puzzle into account


_NB: the `api/fake-perfect` route is not getting checked in ;)_

## Demo

<!-- screenshots / screen recording here -->

**Before**

https://github.com/user-attachments/assets/2c5b813f-254a-46b8-902f-c46a50c05ccf

**After**

https://github.com/user-attachments/assets/6004c157-101d-4b38-ae50-a984e9974d52